### PR TITLE
Added Avalanche warning for Neltharion's Lair Trash

### DIFF
--- a/Legion/NeltharionsLair/Trash.lua
+++ b/Legion/NeltharionsLair/Trash.lua
@@ -45,5 +45,4 @@ end
 
 function mod:Avalanche(args)
 	self:Message(args.spellId, "Attention", "Long")
-	--self:Bar(args.spellId, 2, CL.cast:format(args.spellName))
 end

--- a/Legion/NeltharionsLair/Trash.lua
+++ b/Legion/NeltharionsLair/Trash.lua
@@ -1,0 +1,49 @@
+--------------------------------------------------------------------------------
+-- Module Declaration
+--
+
+local mod, CL = BigWigs:NewBoss("Neltharions Lair Trash", 1065)
+if not mod then return end
+mod.displayName = CL.trash
+mod:RegisterEnableMob(
+	113998, -- Mightstone Breaker
+	90997, -- Mightstone Breaker
+	92612, -- Mightstone Breaker
+	113538 -- Mightstone Breaker
+)
+
+--------------------------------------------------------------------------------
+-- Localization
+--
+
+local L = mod:NewLocale("enUS", true)
+if L then
+	L.breaker = "Mightstone Breaker"
+end
+L = mod:GetLocale()
+
+--------------------------------------------------------------------------------
+-- Initialization
+--
+
+function mod:GetOptions()
+	return {
+		183088 -- Avalanche
+	}, {
+		[183088] = L.breaker
+	}
+end
+
+function mod:OnBossEnable()
+	self:RegisterMessage("BigWigs_OnBossEngage", "Disable")
+	self:Log("SPELL_CAST_START", "Avalanche", 183088)
+end
+
+--------------------------------------------------------------------------------
+-- Event Handlers
+--
+
+function mod:Avalanche(args)
+	self:Message(args.spellId, "Attention", "Long")
+	--self:Bar(args.spellId, 2, CL.cast:format(args.spellName))
+end

--- a/Legion/NeltharionsLair/modules.xml
+++ b/Legion/NeltharionsLair/modules.xml
@@ -5,6 +5,7 @@
 <Script file="UlaroggCragshaper.lua"/>
 <Script file="Naraxas.lua"/>
 <Script file="Dargrul.lua"/>
+<Script file="Trash.lua"/>
 
 </Ui>
 


### PR DESCRIPTION
Adds a Trash module to Neltharion's Lair and an Avalanche warning to the Breaker mobs.
It's pretty important to walk out of it on higher M+

For some reason there are multiple IDs of Breaker mobs but I've included them all.