### PR TITLE
VaultOfTheWardens/Tormentorum: handle "Flesh to Stone" and "Shadow Crash", refactor UNIT_HEALTH_FREQUENT

### DIFF
--- a/Legion/VaultOfTheWardens/Tormentorum.lua
+++ b/Legion/VaultOfTheWardens/Tormentorum.lua
@@ -31,6 +31,7 @@ function mod:GetOptions()
 		{200904, "FLASH"}, -- Sapped Soul
 		196208, -- Seed of Corruption
 		201488, -- Frightening Shout
+		199918, -- Shadow Crash
 	}
 end
 
@@ -46,6 +47,9 @@ function mod:OnBossEnable()
 	self:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", nil, "boss1")
 	self:Log("SPELL_CAST_START", "SeedofCorruption", 196208)
 	self:Log("SPELL_CAST_START", "FrighteningShout", 201488)
+	self:Log("SPELL_AURA_APPLIED", "ShadowCrashDamage", 199918) -- Shadow Crash
+	self:Log("SPELL_PERIODIC_DAMAGE", "ShadowCrashDamage", 199918)
+	self:Log("SPELL_PERIODIC_MISSED", "ShadowCrashDamage", 199918)
 end
 
 function mod:OnEngage()
@@ -114,4 +118,15 @@ end
 
 function mod:FrighteningShout(args)
 	self:Message(args.spellId, "Urgent", "Warning", CL.casting:format(args.spellName))
+end
+
+do
+	local prev = 0
+	function mod:ShadowCrashDamage(args)
+		local t = GetTime()
+		if self:Me(args.destGUID) and t-prev > 1.5 then
+			prev = t
+			self:Message(args.spellId, "Personal", "Alert", CL.underyou:format(args.spellName))
+		end
+	end
 end

--- a/Legion/VaultOfTheWardens/Tormentorum.lua
+++ b/Legion/VaultOfTheWardens/Tormentorum.lua
@@ -1,9 +1,5 @@
 
 --------------------------------------------------------------------------------
--- TODO List:
--- - UNIT_HEALTH_FREQUENT warnings are coded badly, was in a hurry, fix pls
-
---------------------------------------------------------------------------------
 -- Module Declaration
 --
 
@@ -16,8 +12,7 @@ mod.engageId = 1850
 -- Locals
 --
 
-local warnedForTeleport1 = nil
-local warnedForTeleport2 = nil
+local nextTeleportSoonWarning = 0
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -55,7 +50,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-
+	nextTeleportSoonWarning = 75 -- Teleport at 70%
 end
 
 --------------------------------------------------------------------------------
@@ -104,13 +99,12 @@ end
 
 function mod:UNIT_HEALTH_FREQUENT(unit)
 	local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-	if hp < 75 and not warnedForTeleport1 then -- Teleport at 70%
-		warnedForTeleport1 = true
-		self:Message(200898, "Attention", nil, CL.soon:format(self:SpellName(200898))) -- Teleport soon
-	elseif hp < 45 and not warnedForTeleport2 then -- Teleport at 40%
-		warnedForTeleport2 = true
-		self:Message(200898, "Important", nil, CL.soon:format(self:SpellName(200898))) -- Teleport soon
-		self:UnregisterUnitEvent("UNIT_HEALTH_FREQUENT", unit)
+	if hp < nextTeleportSoonWarning then
+		self:Message(200898, "Attention", nil, CL.soon:format(self:SpellName(200898)))
+		nextTeleportSoonWarning = nextTeleportSoonWarning - 30 -- Teleport at 40%
+		if nextTeleportSoonWarning < 40 then
+			self:UnregisterUnitEvent("UNIT_HEALTH_FREQUENT", unit)
+		end
 	end
 end
 

--- a/Legion/VaultOfTheWardens/Tormentorum.lua
+++ b/Legion/VaultOfTheWardens/Tormentorum.lua
@@ -32,6 +32,7 @@ function mod:GetOptions()
 		196208, -- Seed of Corruption
 		201488, -- Frightening Shout
 		199918, -- Shadow Crash
+		203685, -- Flesh to Stone
 	}
 end
 
@@ -50,6 +51,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "ShadowCrashDamage", 199918) -- Shadow Crash
 	self:Log("SPELL_PERIODIC_DAMAGE", "ShadowCrashDamage", 199918)
 	self:Log("SPELL_PERIODIC_MISSED", "ShadowCrashDamage", 199918)
+	self:Log("SPELL_AURA_APPLIED_DOSE", "FleshToStoneApplied", 203685)
 end
 
 function mod:OnEngage()
@@ -127,6 +129,58 @@ do
 		if self:Me(args.destGUID) and t-prev > 1.5 then
 			prev = t
 			self:Message(args.spellId, "Personal", "Alert", CL.underyou:format(args.spellName))
+		end
+	end
+end
+
+do
+	local scheduled, spellName = nil, mod:SpellName(203685)
+
+	local function sortTable(x, y)
+		if x.stacks == y.stacks then
+			return x.name > y.name
+		else
+			return x.stacks > y.stacks
+		end
+	end
+
+	local function printStacks(self, spellId)
+		local meOnly = self:CheckOption(spellId, "ME_ONLY")
+		if meOnly then
+			local stacks = select(4, UnitDebuff("player", spellName)) or 0
+			if stacks > 6 then
+				self:StackMessage(spellId, self:UnitName("player"), stacks, "Urgent", stacks < 9 and "Alarm" or "Warning")
+			end
+		else
+			local stacksOnMe = 0
+			local affectedPlayers = {}
+			for unit in self:IterateGroup() do
+				local stacks = select(4, UnitDebuff(unit, spellName)) or 0
+				if stacks > 6 then
+					affectedPlayers[#affectedPlayers + 1] = { name = self:UnitName(unit), stacks = stacks }
+					if UnitIsUnit("player", unit) then
+						stacksOnMe = stacks
+					end
+				end
+			end
+			if #affectedPlayers == 1 then
+				self:StackMessage(spellId, affectedPlayers[1].name, affectedPlayers[1].stacks, "Urgent", (self:UnitName("player") == affectedPlayers[1].name or self:Dispeller("magic")) and (affectedPlayers[1].stacks < 9 and "Alarm" or "Warning"))
+			elseif #affectedPlayers > 1 then
+				table.sort(affectedPlayers, sortTable)
+				for i, v in ipairs(affectedPlayers) do
+					affectedPlayers[i] = CL.count:format(self:ColorName(v.name), v.stacks)
+				end
+				local list = table.concat(affectedPlayers, ", ")
+				local stacksOfInterest = self:Dispeller("magic") and affectedPlayers[1].stacks or stacksOnMe
+				self:Message(spellId, "Urgent", stacksOfInterest > 8 and "Warning" or stacksOfInterest > 6 and "Alarm", CL.other:format(spellName, list))
+			end
+		end
+		scheduled = nil
+	end
+
+	function mod:FleshToStoneApplied(args)
+		if not scheduled then
+			scheduled = self:ScheduleTimer(printStacks, 0.3, self, args.spellId)
 		end
 	end
 end


### PR DESCRIPTION
Commits' messages are more descriptive.

Went with `"Urgent"` and `"Warning"` for "Flesh to Stone" because that seems to be what this module uses for abilities of summoned adds.