### PR TITLE
Karazhan/Trash: do not warn about DK-controlled units casting "Shield Smash" and "Banshee Wail", closes #156

### DIFF
--- a/Legion/Karazhan/Trash.lua
+++ b/Legion/Karazhan/Trash.lua
@@ -129,7 +129,9 @@ function mod:AlluringAura(args)
 end
 
 function mod:BansheeWail(args)
-	self:Message(args.spellId, "Attention", "Warning", CL.casting:format(args.spellName))
+	if bit.band(args.sourceFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) == 0 then -- these NPCs can be mind-controlled by DKs
+		self:Message(args.spellId, "Attention", "Warning", CL.casting:format(args.spellName))
+	end
 end
 
 -- Ghostly Philanthropist

--- a/Legion/Karazhan/Trash.lua
+++ b/Legion/Karazhan/Trash.lua
@@ -153,7 +153,7 @@ end
 do
 	local prev = 0
 	function mod:ShieldSmash(args)
-		if bit.band(args.sourceFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) ~= 0 then
+		if bit.band(args.sourceFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) ~= 0 then -- these NPCs can be mind-controlled by DKs
 			return
 		end
 		local t = GetTime()

--- a/Legion/Karazhan/Trash.lua
+++ b/Legion/Karazhan/Trash.lua
@@ -105,15 +105,15 @@ function mod:GOSSIP_SHOW()
 end
 
 function mod:Warmup(_, msg)
-	if msg:find(L.opera_hall_westfall_story_trigger, nil, true) then 
+	if msg:find(L.opera_hall_westfall_story_trigger, nil, true) then
 		self:Bar("warmup", 42, L.opera_hall_westfall_story_text, "achievement_raid_karazhan")
 	end
 
-	if msg:find(L.opera_hall_beautiful_beast_story_trigger, nil, true) then 
+	if msg:find(L.opera_hall_beautiful_beast_story_trigger, nil, true) then
 		self:Bar("warmup", 47, L.opera_hall_beautiful_beast_story_text, "achievement_raid_karazhan")
 	end
 
-	if msg:find(L.opera_hall_wikket_story_trigger, nil, true) then 
+	if msg:find(L.opera_hall_wikket_story_trigger, nil, true) then
 		self:Bar("warmup", 70, L.opera_hall_wikket_story_text, "achievement_raid_karazhan")
 	end
 end
@@ -153,6 +153,9 @@ end
 do
 	local prev = 0
 	function mod:ShieldSmash(args)
+		if bit.band(args.sourceFlags, COMBATLOG_OBJECT_REACTION_FRIENDLY) ~= 0 then
+			return
+		end
 		local t = GetTime()
 		if t-prev > 1.5 then
 			prev = t


### PR DESCRIPTION
Fixes #156.