### PR TITLE
SeatOfTheTriumvirate/Trash: added warnings for "Void Diffusion" and "Dark Matter"

### DIFF
--- a/Legion/SeatOfTheTriumvirate/Locales/deDE.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/deDE.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/esES.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/esES.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/frFR.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/frFR.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/itIT.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/itIT.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/koKR.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/koKR.lua
@@ -16,4 +16,6 @@ if L then
 	L.alleria = "알레리아 윈드러너"
 	L.subjugator = "어둠수호병 정복자"
 	L.voidbender = "어둠수호병 공허술사"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/ptBR.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/ptBR.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/ruRU.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/ruRU.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/zhCN.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/zhCN.lua
@@ -16,4 +16,6 @@ if L then
 	L.alleria = "奥蕾莉亚·风行者"
 	L.subjugator = "影卫征服者"
 	L.voidbender = "影卫缚灵师"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Locales/zhTW.lua
+++ b/Legion/SeatOfTheTriumvirate/Locales/zhTW.lua
@@ -16,4 +16,6 @@ if L then
 	--L.alleria = "Alleria Windrunner"
 	--L.subjugator = "Shadowguard Subjugator"
 	--L.voidbender = "Shadowguard Voidbender"
+	--L.conjurer = "Shadowguard Conjurer"
+	--L.weaver = "Grand Shadow-Weaver"
 end

--- a/Legion/SeatOfTheTriumvirate/Trash.lua
+++ b/Legion/SeatOfTheTriumvirate/Trash.lua
@@ -9,7 +9,9 @@ mod.displayName = CL.trash
 mod:RegisterEnableMob(
 	125836, -- Alleria Windrunner
 	124171, -- Shadowguard Subjugator
-	122404 -- Shadowguard Voidbender
+	122404, -- Shadowguard Voidbender
+	122405, -- Shadowguard Conjurer
+	122423 -- Grand Shadow-Weaver
 )
 
 --------------------------------------------------------------------------------
@@ -27,22 +29,30 @@ if L then
 	L.alleria = "Alleria Windrunner"
 	L.subjugator = "Shadowguard Subjugator"
 	L.voidbender = "Shadowguard Voidbender"
+	L.conjurer = "Shadowguard Conjurer"
+	L.weaver = "Grand Shadow-Weaver"
 end
 
 --------------------------------------------------------------------------------
 -- Initialization
 --
 
+local matterMarker = mod:AddMarkerOption(true, "npc", 8, 248227, 8) -- Unstable Dark Matter
 function mod:GetOptions()
 	return {
 		"custom_on_autotalk",
 		"warmup",
 		{249081, "SAY"}, -- Suppression Field
 		{245510, "SAY"}, -- Corrupting Void
+		249078, -- Void Diffusion
+		248227, -- Dark Matter
+		matterMarker,
 	}, {
 		["custom_on_autotalk"] = L.alleria,
 		[249081] = L.subjugator,
 		[245510] = L.voidbender,
+		[249078] = L.conjurer,
+		[248227] = L.weaver,
 	}
 end
 
@@ -52,6 +62,9 @@ function mod:OnBossEnable()
 	self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
 
 	self:Log("SPELL_AURA_APPLIED", "PersonalAurasWithSay", 249081, 245510) -- Suppression Field, Corrupting Void
+	self:Log("SPELL_CAST_START", "VoidDiffusionCast", 249078)
+	self:Log("SPELL_CAST_START", "DarkMatterCast", 248227)
+	self:Log("SPELL_CAST_START", "CollapseCast", 248228)
 
 	self:RegisterEvent("GOSSIP_SHOW")
 end
@@ -71,6 +84,28 @@ function mod:PersonalAurasWithSay(args)
 		self:TargetMessage(args.spellId, args.destName, "Personal", "Alarm")
 		self:Say(args.spellId)
 	end
+end
+
+function mod:VoidDiffusionCast(args)
+	self:Message(args.spellId, "Attention", self:Interrupter() and "Info", CL.casting:format(args.spellName))
+end
+
+function mod:DarkMatterCast(args)
+	self:Message(args.spellId, "Important", "Warning", CL.casting:format(args.spellName))
+	if self:GetOption(matterMarker) then
+		self:RegisterTargetEvents("MarkMatter")
+	end
+end
+
+function mod:MarkMatter(event, unit, guid)
+	if self:MobId(guid) == 124964 then -- Unstable Dark Matter
+		SetRaidTarget(unit, 8)
+		self:UnregisterTargetEvents()
+	end
+end
+
+function mod:CollapseCast(args)
+	self:CastBar(248227, 4.9, args.spellId)
 end
 
 function mod:GOSSIP_SHOW()


### PR DESCRIPTION
"Void Diffusion" destroys melees on Fortified and can be interrupted. "Dark Matter" destroys the whole group unless you kill the mob it spawns.