### PR TITLE
Karazhan/Moroes: warn when Mana Drain is being casted rather than when it's already applied

### DIFF
--- a/Legion/Karazhan/Moroes.lua
+++ b/Legion/Karazhan/Moroes.lua
@@ -35,7 +35,7 @@ function mod:GetOptions()
 		227872, -- Ghastly Purge
 
 		--[[ Baroness Dorothea Millstripe ]]--
-		227545, -- Mana Drain
+		{227545, "SAY"}, -- Mana Drain
 
 		--[[ Lady Catriona Von'Indi ]]--
 		-- Healing Stream? wasn't in any of my logs
@@ -72,7 +72,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "GhastlyPurge", 227872)
 
 	--[[ Baroness Dorothea Millstripe ]]--
-	self:Log("SPELL_AURA_APPLIED", "ManaDrain", 227545)
+	self:Log("SPELL_CAST_START", "ManaDrain", 227545)
+	self:Log("SPELL_AURA_APPLIED", "ManaDrainApplied", 227545)
 
 	--[[ Lady Catriona Von'Indi ]]--
 
@@ -153,8 +154,14 @@ function mod:GhastlyPurge(args)
 end
 
 function mod:ManaDrain(args)
-	self:TargetMessage(args.spellId, args.destName, "Urgent", "Warning", nil, nil, self:Dispeller("magic"))
+	self:Message(args.spellId, "Urgent", self:Interrupter() and "Warning", CL.casting:format(args.spellName))
 	self:CDBar(args.spellId, 18)
+end
+
+function mod:ManaDrainApplied(args)
+	if self:Me(args.destGUID) then
+		self:Say(args.spellId)
+	end
 end
 
 function mod:IronWhirlwind(args)

--- a/Legion/Karazhan/Moroes.lua
+++ b/Legion/Karazhan/Moroes.lua
@@ -35,7 +35,7 @@ function mod:GetOptions()
 		227872, -- Ghastly Purge
 
 		--[[ Baroness Dorothea Millstripe ]]--
-		{227545, "SAY"}, -- Mana Drain
+		227545, -- Mana Drain
 
 		--[[ Lady Catriona Von'Indi ]]--
 		-- Healing Stream? wasn't in any of my logs

--- a/Legion/Karazhan/Moroes.lua
+++ b/Legion/Karazhan/Moroes.lua
@@ -73,7 +73,6 @@ function mod:OnBossEnable()
 
 	--[[ Baroness Dorothea Millstripe ]]--
 	self:Log("SPELL_CAST_START", "ManaDrain", 227545)
-	self:Log("SPELL_AURA_APPLIED", "ManaDrainApplied", 227545)
 
 	--[[ Lady Catriona Von'Indi ]]--
 
@@ -156,12 +155,6 @@ end
 function mod:ManaDrain(args)
 	self:Message(args.spellId, "Urgent", self:Interrupter() and "Warning", CL.casting:format(args.spellName))
 	self:CDBar(args.spellId, 18)
-end
-
-function mod:ManaDrainApplied(args)
-	if self:Me(args.destGUID) then
-		self:Say(args.spellId)
-	end
 end
 
 function mod:IronWhirlwind(args)


### PR DESCRIPTION
This mechanic consistently targets the healer, so, unless you have a shadow priest or are running with multiple healers(?), dispelling it is not the way to go (it stuns its target, at least on Mythic). Fortunately, it can be interrupted. And, AFAIK, you have about 1s to interrupt it before it actually starts channeling, so this also gives you an earlier warning.