### PR TITLE
Cataclysm/ThroneOfTheTides: various improvements

### DIFF
--- a/Cataclysm/ThroneTides/Locales/deDE.lua
+++ b/Cataclysm/ThroneTides/Locales/deDE.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "deDE")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Locales/esES.lua
+++ b/Cataclysm/ThroneTides/Locales/esES.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "esES") or BigWigs:NewBossLocale("Ozumat", "esMX")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Locales/frFR.lua
+++ b/Cataclysm/ThroneTides/Locales/frFR.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "frFR")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Locales/itIT.lua
+++ b/Cataclysm/ThroneTides/Locales/itIT.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "itIT")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Locales/koKR.lua
+++ b/Cataclysm/ThroneTides/Locales/koKR.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "koKR")
+if not L then return end
+if L then
+	L.custom_on_autotalk = "자동 대화"
+	L.custom_on_autotalk_desc = "전투를 시작하는 대화 선택지를 즉시 선택합니다."
+end

--- a/Cataclysm/ThroneTides/Locales/ptBR.lua
+++ b/Cataclysm/ThroneTides/Locales/ptBR.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "ptBR")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Locales/ruRU.lua
+++ b/Cataclysm/ThroneTides/Locales/ruRU.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "ruRU")
+if not L then return end
+if L then
+	L.custom_on_autotalk = "Авторазговор"
+	L.custom_on_autotalk_desc = "Мгновенный выбор опции запуска боя в диалоге."
+end

--- a/Cataclysm/ThroneTides/Locales/zhCN.lua
+++ b/Cataclysm/ThroneTides/Locales/zhCN.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "zhCN")
+if not L then return end
+if L then
+	L.custom_on_autotalk = "自动对话"
+	L.custom_on_autotalk_desc = "立即选择对话选项开始战斗。"
+end

--- a/Cataclysm/ThroneTides/Locales/zhTW.lua
+++ b/Cataclysm/ThroneTides/Locales/zhTW.lua
@@ -1,0 +1,6 @@
+local L = BigWigs:NewBossLocale("Ozumat", "zhTW")
+if not L then return end
+if L then
+	--L.custom_on_autotalk = "Autotalk"
+	--L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end

--- a/Cataclysm/ThroneTides/Mindbender.lua
+++ b/Cataclysm/ThroneTides/Mindbender.lua
@@ -6,6 +6,8 @@
 local mod, CL = BigWigs:NewBoss("Mindbender Ghur'sha", 767, 103)
 if not mod then return end
 mod:RegisterEnableMob(40788, 40825)
+mod.engageId = 1046
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -26,9 +28,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "AbsorbMagic", 76307)
 	self:Log("SPELL_AURA_APPLIED", "MindFog", 76230)
 
-	self:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", nil, "target", "focus")
-
-	self:Death("Win", 40788)
+	self:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", nil, "boss1")
 end
 
 --------------------------------------------------------------------------------
@@ -39,7 +39,7 @@ function mod:UNIT_HEALTH_FREQUENT(unit)
 	if self:MobId(UnitGUID(unit)) == 40825 then -- Erunak Stonespeaker
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
 		if hp < 55 then
-			self:UnregisterUnitEvent("UNIT_HEALTH_FREQUENT", "target", "focus")
+			self:UnregisterUnitEvent("UNIT_HEALTH_FREQUENT", unit)
 			self:Message("stages", "Positive", nil, CL.soon:format(CL.stage:format(2)), false)
 		end
 	end

--- a/Cataclysm/ThroneTides/Naz'jar.lua
+++ b/Cataclysm/ThroneTides/Naz'jar.lua
@@ -36,9 +36,6 @@ end
 --
 
 function mod:Waterspout(args)
-	local overMsg = CL.over:format(args.spellName)
-	overMsg = overMsg:sub(0, overMsg:len() - 1) -- remove the "!"
-	self:DelayedMessage(args.spellId, 50, "Attention", CL.custom_sec:format(overMsg, 10))
 	self:CastBar(args.spellId, 60)
 end
 

--- a/Cataclysm/ThroneTides/Naz'jar.lua
+++ b/Cataclysm/ThroneTides/Naz'jar.lua
@@ -6,8 +6,10 @@
 local mod, CL = BigWigs:NewBoss("Lady Naz'jar", 767, 101)
 if not mod then return end
 mod:RegisterEnableMob(40586)
+mod.engageId = 1045
+mod.respawnTime = 30
 
-local spout1 = nil
+local nextSpoutWarning = 66
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -22,13 +24,11 @@ end
 function mod:OnBossEnable()
 	self:RegisterUnitEvent("UNIT_HEALTH_FREQUENT", nil, "boss1")
 	self:Log("SPELL_AURA_APPLIED", "Waterspout", 75683)
-
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT", "CheckBossStatus")
-	self:Death("Win", 40586)
+	self:Log("SPELL_AURA_REMOVED", "WaterspoutRemoved", 75683)
 end
 
 function mod:OnEngage()
-	spout1 = nil
+	nextSpoutWarning = 66
 end
 
 --------------------------------------------------------------------------------
@@ -36,19 +36,24 @@ end
 --
 
 function mod:Waterspout(args)
-	self:Bar(args.spellId, 60)
-	self:DelayedMessage(args.spellId, 50, CL.custom_sec:format(CL.over:format(args.spellName), 10), "Attention") -- XXX fix "!" in string
+	local overMsg = CL.over:format(args.spellName)
+	overMsg = overMsg:sub(0, overMsg:len() - 1) -- remove the "!"
+	self:DelayedMessage(args.spellId, 50, "Attention", CL.custom_sec:format(overMsg, 10))
+	self:CastBar(args.spellId, 60)
+end
+
+function mod:WaterspoutRemoved(args) -- if all 3 adds die, she stops casting
+	self:CancelDelayedMessage(args.spellId)
+	self:StopBar(CL.cast(args.spellName))
 end
 
 function mod:UNIT_HEALTH_FREQUENT(unit)
-	if self:MobId(UnitGUID(unit)) == 40586 then
-		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-		if hp < 69 and not spout1 then
-			spout1 = true
-			self:Message(75683, "Attention", nil, CL.soon:format(self:SpellName(75683)), false)
-		elseif hp < 36 then
+	local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
+	if hp < nextSpoutWarning then
+		self:Message(75683, "Attention", nil, CL.soon:format(self:SpellName(75683)), false)
+		nextSpoutWarning = nextSpoutWarning - 30
+		if nextSpoutWarning < 36 then
 			self:UnregisterUnitEvent("UNIT_HEALTH_FREQUENT", unit)
-			self:Message(75683, "Attention", nil, CL.soon:format(self:SpellName(75683)), false)
 		end
 	end
 end

--- a/Cataclysm/ThroneTides/Naz'jar.lua
+++ b/Cataclysm/ThroneTides/Naz'jar.lua
@@ -36,11 +36,11 @@ end
 --
 
 function mod:Waterspout(args)
-	self:CastBar(args.spellId, 60)
+	self:Bar(args.spellId, 60)
 end
 
 function mod:WaterspoutRemoved(args) -- if all 3 adds die, she stops casting
-	self:StopBar(CL.cast(args.spellName))
+	self:StopBar(args.spellId)
 end
 
 function mod:UNIT_HEALTH_FREQUENT(unit)

--- a/Cataclysm/ThroneTides/Naz'jar.lua
+++ b/Cataclysm/ThroneTides/Naz'jar.lua
@@ -40,7 +40,6 @@ function mod:Waterspout(args)
 end
 
 function mod:WaterspoutRemoved(args) -- if all 3 adds die, she stops casting
-	self:CancelDelayedMessage(args.spellId)
 	self:StopBar(CL.cast(args.spellName))
 end
 

--- a/Cataclysm/ThroneTides/Ozumat.lua
+++ b/Cataclysm/ThroneTides/Ozumat.lua
@@ -1,0 +1,77 @@
+
+--------------------------------------------------------------------------------
+-- Module Declaration
+--
+
+local mod, CL = BigWigs:NewBoss("Ozumat", 767, 104)
+if not mod then return end
+mod:RegisterEnableMob(40792, 44566) -- Neptulon, Ozumat
+mod.engageId = 1047
+mod.respawnTime = 26
+
+--------------------------------------------------------------------------------
+-- Localization
+--
+
+local L = mod:GetLocale()
+if L then
+	L.custom_on_autotalk = "Autotalk"
+	L.custom_on_autotalk_desc = "Instantly selects the gossip option to start the fight."
+end
+
+--------------------------------------------------------------------------------
+-- Initialization
+--
+
+function mod:GetOptions()
+	return {
+		"custom_on_autotalk",
+		"stages",
+	}
+end
+
+function mod:OnBossEnable()
+	self:Log("SPELL_CAST_SUCCESS", "EntanglingGrasp", 83463) -- Entangling Grasp, 3 adds that need to be killed in P2 cast this on Neptulon
+	self:Log("SPELL_AURA_REMOVED", "EntanglingGraspRemoved", 83463)
+	self:Log("SPELL_CAST_SUCCESS", "TidalSurge", 76133) -- the buff Neptulon applies to players in P3
+	self:RegisterEvent("GOSSIP_SHOW")
+end
+
+function mod:OnEngage()
+	-- this stage lasts 1:40 on both difficulties, EJ's entry is incorrect
+	self:Bar("stages", 100, CL.stage:format(1), "Achievement_Dungeon_Throne of the Tides") -- Yes, " " is the correct delimiter.
+	self:DelayedMessage("stages", 90, "Attention", CL.soon:format(CL.stage:format(2)))
+end
+
+--------------------------------------------------------------------------------
+-- Event Handlers
+--
+
+do
+	local prev, addsAlive = 0, 0
+	function mod:EntanglingGrasp(args)
+		addsAlive = addsAlive + 1
+
+		local t = GetTime()
+		if t-prev > 10 then
+			prev = t
+			self:Message("stages", "Attention", "Info", CL.stage:format(2), false)
+		end
+	end
+	function mod:EntanglingGraspRemoved(args)
+		addsAlive = addsAlive - 1
+		self:Message("stages", "Positive", nil, CL.add_remaining:format(addsAlive), false)
+	end
+end
+
+function mod:TidalSurge(args)
+	self:Message("stages", "Attention", "Info", CL.stage:format(3), false)
+end
+
+function mod:GOSSIP_SHOW()
+	if self:GetOption("custom_on_autotalk") and self:MobId(UnitGUID("npc")) == 40792 then
+		if GetGossipOptions() then
+			SelectGossipOption(1, "", true) -- auto confirm it
+		end
+	end
+end

--- a/Cataclysm/ThroneTides/Ulthok.lua
+++ b/Cataclysm/ThroneTides/Ulthok.lua
@@ -6,6 +6,8 @@
 local mod, CL = BigWigs:NewBoss("Commander Ulthok", 767, 102)
 if not mod then return end
 mod:RegisterEnableMob(40765)
+mod.engageId = 1044
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -15,14 +17,16 @@ function mod:GetOptions()
 	return {
 		76047, -- Dark Fissure
 		{76026, "ICON"}, -- Squeeze
+		76094, -- Curse of Fatigue
 		76100, -- Enrage
 	}
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_CAST_START", "Fissure", 76047)
+	self:Log("SPELL_CAST_START", "DarkFissure", 76047)
 	self:Log("SPELL_AURA_APPLIED", "Squeeze", 76026)
 	self:Log("SPELL_AURA_REMOVED", "SqueezeRemoved", 76026)
+	self:Log("SPELL_AURA_APPLIED", "CurseOfFatigue", 76094)
 	self:Log("SPELL_AURA_APPLIED", "Enrage", 76100)
 	self:Death("Win", 40765)
 end
@@ -31,7 +35,7 @@ end
 -- Event Handlers
 --
 
-function mod:Fissure(args)
+function mod:DarkFissure(args)
 	self:Message(args.spellId, "Important", nil, CL.casting:format(args.spellName))
 end
 
@@ -44,7 +48,12 @@ function mod:SqueezeRemoved(args)
 	self:PrimaryIcon(args.spellId)
 end
 
+function mod:CurseOfFatigue(args)
+	if self:Me(args.destGUID) or self:Dispeller("curse") then
+		self:TargetMessage(args.spellId, args.destName, "Attention")
+	end
+end
+
 function mod:Enrage(args)
 	self:Message(args.spellId, "Attention")
 end
-

--- a/Cataclysm/ThroneTides/locales.xml
+++ b/Cataclysm/ThroneTides/locales.xml
@@ -1,0 +1,11 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+<Script file="Locales\deDE.lua"/>
+<Script file="Locales\esES.lua"/>
+<Script file="Locales\esMX.lua"/>
+<Script file="Locales\frFR.lua"/>
+<Script file="Locales\koKR.lua"/>
+<Script file="Locales\zhCN.lua"/>
+<Script file="Locales\zhTW.lua"/>
+<Script file="Locales\ruRU.lua"/>
+</Ui>

--- a/Cataclysm/ThroneTides/locales.xml
+++ b/Cataclysm/ThroneTides/locales.xml
@@ -1,11 +1,14 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
 ..\FrameXML\UI.xsd">
+
 <Script file="Locales\deDE.lua"/>
 <Script file="Locales\esES.lua"/>
-<Script file="Locales\esMX.lua"/>
 <Script file="Locales\frFR.lua"/>
+<Script file="Locales\itIT.lua"/>
 <Script file="Locales\koKR.lua"/>
+<Script file="Locales\ptBR.lua"/>
+<Script file="Locales\ruRU.lua"/>
 <Script file="Locales\zhCN.lua"/>
 <Script file="Locales\zhTW.lua"/>
-<Script file="Locales\ruRU.lua"/>
+
 </Ui>

--- a/Cataclysm/ThroneTides/modules.xml
+++ b/Cataclysm/ThroneTides/modules.xml
@@ -4,6 +4,7 @@
 <Script file="Naz'jar.lua"/>
 <Script file="Ulthok.lua"/>
 <Script file="Mindbender.lua"/>
+<Script file="Ozumat.lua"/>
 
 </Ui>
 

--- a/modules.xml
+++ b/modules.xml
@@ -57,6 +57,7 @@
 <Include file="Cataclysm\Stonecore\modules.xml"/>
 <Include file="Cataclysm\Stonecore\locales.xml"/>
 <Include file="Cataclysm\ThroneTides\modules.xml"/>
+<Include file="Cataclysm\ThroneTides\locales.xml"/>
 <Include file="Cataclysm\VortexPinnacle\modules.xml"/>
 <!--<Include file="Cataclysm\WellOfEternity\modules.xml"/>-->
 <!--<Include file="Cataclysm\ZulAman\modules.xml"/>-->


### PR DESCRIPTION
- Added a module for Ozumat that includes an option to automatically start the encounter, a timer for Stage 1 and tracking of adds killed in Stage 2.
- Mindbender: there's a boss unit now, so it's being used for HP tracking instead of target/focus.
- Naz'jar: if "Waterspout" ends early, its bar gets removed.
- Ulthok: now warns those who can dispel curses about "Curse of Fatigue", also warns its victims.
- All of them now use ENCOUNTER_START and ENCOUNTER_END and have timers for their respawns.