### PR TITLE
Provide 2nd arg to :GetBossModule() calls to prevent Lua errors on failure

### DIFF
--- a/Legion/HallsOfValor/God-KingSkovald.lua
+++ b/Legion/HallsOfValor/God-KingSkovald.lua
@@ -52,7 +52,7 @@ function mod:OnEngage()
 end
 
 function mod:OnWin()
-	local odynMod = BigWigs:GetBossModule("Odyn")
+	local odynMod = BigWigs:GetBossModule("Odyn", true)
 	if odynMod then
 		odynMod:Enable() -- Making sure to pickup the Odyn's yell to start the RP bar
 	end

--- a/Legion/SeatOfTheTriumvirate/Zuraal.lua
+++ b/Legion/SeatOfTheTriumvirate/Zuraal.lua
@@ -46,7 +46,7 @@ function mod:OnEngage()
 end
 
 function mod:OnWin()
-	local trashMod = BigWigs:GetBossModule("Seat of the Triumvirate Trash")
+	local trashMod = BigWigs:GetBossModule("Seat of the Triumvirate Trash", true)
 	if trashMod then
 		trashMod:Enable() -- Making sure to pickup the Alleria yell to start the RP bar
 	end


### PR DESCRIPTION
Shouldn't really happen, but what if. We are checking against `nil` anyway.