### PR TITLE
MawOfSouls/Helya: Change 'Brackwater Barrage' sound from 'Info' to 'Alarm'

### DIFF
--- a/Legion/MawOfSouls/Helya.lua
+++ b/Legion/MawOfSouls/Helya.lua
@@ -160,6 +160,6 @@ function mod:CorruptedBellow(args)
 end
 
 function mod:BrackwaterBarrage(args)
-	self:Message(args.spellId, "Urgent", "Info")
+	self:Message(args.spellId, "Urgent", "Alarm")
 	self:CDBar(args.spellId, 22.2)
 end


### PR DESCRIPTION
Hi,

Currently Brackwater Barrage on Helya has an associated severity of Info. I believe the ability should be presented as an Alarm (similar to corrupted below, as they do similar amounts of damage). To me, "Alarm" always feels like something I need to look at immediately, and indicates something like one shot mechanics, or something that will wipe the group. I think this is a better indication of the severity of the ability. 