### PR TITLE
BfA/KingsRest: Uncomment locales.xml

### DIFF
--- a/modules.xml
+++ b/modules.xml
@@ -185,7 +185,7 @@
 <Include file="BfA\Freehold\locales.xml"/>
 
 <Include file="BfA\KingsRest\modules.xml"/>
-<!--<Include file="BfA\KingsRest\locales.xml"/>-->
+<Include file="BfA\KingsRest\locales.xml"/>
 
 <Include file="BfA\ShrineOfTheStorm\modules.xml"/>
 <Include file="BfA\ShrineOfTheStorm\locales.xml"/>


### PR DESCRIPTION
Looks like the King's Rest locales.xml is commented out by mistake. The locale files are all there in BfA/KingsRest/Locales