### PR TITLE
TBC/TheBotanica/WarpSplinter: Fix spell ID for "Heal".

### DIFF
--- a/TBC/TheBotanica/WarpSplinter.lua
+++ b/TBC/TheBotanica/WarpSplinter.lua
@@ -55,7 +55,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 34741 then -- Summon Saplings
 		addsAlive = 6 -- when they despawn to heal him, they don't fire any events; fortunately, no 2 waves can be alive at the same time
 		self:Message(-5478, "red", "Alarm")
-		self:Bar(-5478, 25, CL.onboss:format(self:SpellName(32130)), 38658) -- text is "Heal on BOSS", icon is that of druids' Healing Touch
+		self:Bar(-5478, 25, CL.onboss:format(self:SpellName(2060)), 38658) -- text is "Heal on BOSS", icon is that of druids' Healing Touch
 		self:CDBar(-5478, 45)
 	end
 end
@@ -64,6 +64,6 @@ function mod:AddDeath()
 	addsAlive = addsAlive - 1
 	self:Message(-5478, "green", "Info", CL.add_remaining:format(addsAlive))
 	if addsAlive == 0 then
-		self:StopBar(CL.onboss:format(self:SpellName(32130))) -- "Heal on BOSS"
+		self:StopBar(CL.onboss:format(self:SpellName(2060))) -- "Heal on BOSS"
 	end
 end


### PR DESCRIPTION
The spell ID 32130 for the old "Heal" spell is no longer in the
game, so use the spell ID 2060 for the priest's current Heal spell.
This fixes the "Heal on BOSS" string used on the bar.