### PR TITLE
BfA/TheMotherlode/CrowdPummler: Fix timers

### DIFF
--- a/BfA/TheMotherlode/CrowdPummeler.lua
+++ b/BfA/TheMotherlode/CrowdPummeler.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Coin-Operated Crowd Pummeler", 1594, 2109)
 if not mod then return end
 mod:RegisterEnableMob(129214) -- Coin-Operated Crowd Pummeler
 mod.engageId = 2105
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -17,22 +18,22 @@ function mod:GetOptions()
 		269493, -- Footbomb Launcher
 		256493, -- Blazing Azerite
 		262347, -- Static Pulse
-		257337, -- Chocking Claw
+		257337, -- Shocking Claw
 	}
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_CAST_START", "FootbombLauncher", 269493)
+	self:Log("SPELL_CAST_SUCCESS", "FootbombLauncher", 269493)
 	self:Log("SPELL_AURA_APPLIED", "BlazingAzerite", 256493)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "BlazingAzerite", 256493)
 	self:Log("SPELL_CAST_START", "StaticPulse", 262347)
-	self:Log("SPELL_CAST_START", "ChockingClaw", 257337)
+	self:Log("SPELL_CAST_START", "ShockingClaw", 257337)
 end
 
 function mod:OnEngage()
-	self:Bar(262347, 9) -- Static Pulse
-	self:Bar(269493, 14.5) -- Footbomb Launcher
-	self:Bar(257337, 25.5) -- Chocking Claw
+	self:Bar(262347, 6) -- Static Pulse
+	self:Bar(269493, 9.7) -- Footbomb Launcher
+	self:Bar(257337, 14.2) -- Shocking Claw
 end
 
 --------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ end
 function mod:FootbombLauncher(args)
 	self:Message2(args.spellId, "cyan")
 	self:PlaySound(args.spellId, "long")
-	self:Bar(args.spellId, 33)
+	self:Bar(args.spellId, 34)
 end
 
 do
@@ -64,11 +65,11 @@ end
 function mod:StaticPulse(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "alert", "knockback")
-	self:Bar(args.spellId, 33)
+	self:Bar(args.spellId, 23)
 end
 
-function mod:ChockingClaw(args)
+function mod:ShockingClaw(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm", "watchfront")
-	self:Bar(args.spellId, 33)
+	self:CDBar(args.spellId, 33)
 end


### PR DESCRIPTION
- Fix timers for Footbomb Launcher, Static Pulse, and Shocking Claw
- Add respawn timer
