### PR TITLE
BfA/Freehold: Fix Sweete's Fixate message appearing twice, and fix Booty's Shark Toss timer

### DIFF
--- a/BfA/Freehold/Booty.lua
+++ b/BfA/Freehold/Booty.lua
@@ -88,7 +88,7 @@ function mod:OnEngage()
 	self:UnregisterEvent("CHAT_MSG_MONSTER_YELL")
 	self:UnregisterEvent("CHAT_MSG_MONSTER_SAY")
 
-	self:CDBar(256358, 17) -- Shark Toss
+	self:CDBar(256358, 14) -- Shark Toss
 	self:CDBar(256405, 23) -- Sharknado
 	self:CDBar(256489, 46) -- Rearm
 end
@@ -168,7 +168,7 @@ function mod:SharkToss(args)
 	end
 	self:TargetMessage2(args.spellId, "yellow", args.destName)
 	self:PlaySound(args.spellId, "alert", "watchstep")
-	self:CDBar(args.spellId, sharkTossCount % 2 == 0 and 22 or 30)
+	self:CDBar(args.spellId, sharkTossCount % 2 == 0 and 30 or 20)
 	sharkTossCount = sharkTossCount + 1
 end
 

--- a/BfA/Freehold/Booty.lua
+++ b/BfA/Freehold/Booty.lua
@@ -78,8 +78,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	sharkTossCount = 0
-	sharkTossOffset = 0
 	self:UnregisterEvent("CHAT_MSG_MONSTER_YELL")
 	self:UnregisterEvent("CHAT_MSG_MONSTER_SAY")
 

--- a/BfA/Freehold/Booty.lua
+++ b/BfA/Freehold/Booty.lua
@@ -168,6 +168,7 @@ do
 		local t = args.time
 		-- Starts with either 20s or 30s timer and then alternates
 		self:CDBar(args.spellId, t-prev < 25 and 30 or 20)
+		prev = t
 	end
 end
 

--- a/BfA/Freehold/Booty.lua
+++ b/BfA/Freehold/Booty.lua
@@ -15,12 +15,6 @@ mod:RegisterEnableMob(
 mod.engageId = 2095
 
 --------------------------------------------------------------------------------
--- Locals
---
-
-local sharkTossCount = 0
-
---------------------------------------------------------------------------------
 -- Localization
 --
 
@@ -85,6 +79,7 @@ end
 
 function mod:OnEngage()
 	sharkTossCount = 0
+	sharkTossOffset = 0
 	self:UnregisterEvent("CHAT_MSG_MONSTER_YELL")
 	self:UnregisterEvent("CHAT_MSG_MONSTER_SAY")
 
@@ -162,14 +157,18 @@ function mod:Sharknado(args)
 	self:Bar(args.spellId, 40)
 end
 
-function mod:SharkToss(args)
-	if self:Me(args.destGUID) then
-		self:Say(args.spellId)
+do
+	local prev = 0
+	function mod:SharkToss(args)
+		self:TargetMessage2(args.spellId, "yellow", args.destName)
+		self:PlaySound(args.spellId, "alert", "watchstep")
+		if self:Me(args.destGUID) then
+			self:Say(args.spellId)
+		end
+		local t = args.time
+		-- Starts with either 20s or 30s timer and then alternates
+		self:CDBar(args.spellId, t-prev < 25 and 30 or 20)
 	end
-	self:TargetMessage2(args.spellId, "yellow", args.destName)
-	self:PlaySound(args.spellId, "alert", "watchstep")
-	self:CDBar(args.spellId, sharkTossCount % 2 == 0 and 30 or 20)
-	sharkTossCount = sharkTossCount + 1
 end
 
 function mod:Rearm(args)

--- a/BfA/Freehold/Sweete.lua
+++ b/BfA/Freehold/Sweete.lua
@@ -94,10 +94,12 @@ function mod:Avastye(args)
 end
 
 function mod:BlackPowderBomb(args)
-	if args.sourceGUID ~= args.destGUID and self:Me(args.destGUID) then -- The add buffs itself with the same spell id
+	if args.sourceGUID ~= args.destGUID then
 		self:TargetMessage2(args.spellId, "yellow", args.destName, self:SpellName(244657), args.spellId) -- Fixate
-		self:PlaySound(args.spellId, "warning", "fixate")
-		self:Say(args.spellId, self:SpellName(244657)) -- Fixate
-		self:Flash(args.spellId)
+		if self:Me(args.destGUID) then -- The add buffs itself with the same spell id
+			self:PlaySound(args.spellId, "warning", "fixate")
+			self:Say(args.spellId, self:SpellName(244657)) -- Fixate
+			self:Flash(args.spellId)
+		end
 	end
 end

--- a/BfA/Freehold/Sweete.lua
+++ b/BfA/Freehold/Sweete.lua
@@ -95,7 +95,7 @@ end
 
 function mod:BlackPowderBomb(args)
 	self:TargetMessage2(args.spellId, "yellow", args.destName, self:SpellName(244657), args.spellId) -- Fixate
-	if self:Me(args.destGUID) then
+	if args.sourceGUID ~= args.destGUID and self:Me(args.destGUID) then -- The add buffs itself with the same spell id
 		self:PlaySound(args.spellId, "warning", "fixate")
 		self:Say(args.spellId, self:SpellName(244657)) -- Fixate
 		self:Flash(args.spellId)

--- a/BfA/Freehold/Sweete.lua
+++ b/BfA/Freehold/Sweete.lua
@@ -94,8 +94,8 @@ function mod:Avastye(args)
 end
 
 function mod:BlackPowderBomb(args)
-	self:TargetMessage2(args.spellId, "yellow", args.destName, self:SpellName(244657), args.spellId) -- Fixate
 	if args.sourceGUID ~= args.destGUID and self:Me(args.destGUID) then -- The add buffs itself with the same spell id
+		self:TargetMessage2(args.spellId, "yellow", args.destName, self:SpellName(244657), args.spellId) -- Fixate
 		self:PlaySound(args.spellId, "warning", "fixate")
 		self:Say(args.spellId, self:SpellName(244657)) -- Fixate
 		self:Flash(args.spellId)


### PR DESCRIPTION
Sweete: The add applies the fixate aura to itself as well as the target
Booty: The timer alternates between 20 and 30, but it's random which one it starts with