### PR TITLE
BfA/ShrineOfTheStorm: Improve timers and messages for Aqu'sirr, Council, and Stormsong

### DIFF
--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -80,7 +80,7 @@ do
 	local prev = 0
 	function mod:ChokingBrine(args)
 		local t = args.time
-		if t-prev > 2 then
+		if t-prev > 10 then
 			prev = t
 			self:Bar(args.spellId, 32)
 		end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -132,7 +132,7 @@ function mod:GraspFromTheDepths(args)
 end
 
 function mod:EruptingWaters(args)
-	self:Message2("stages", "cyan", CL.intermission)
+	self:Message2("stages", "cyan", CL.intermission, false)
 	self:PlaySound("stages", "long", "intermission")
 	self:Bar(264560, 13.5) -- Choking Brine _success
 	self:Bar(264101, 18.5) -- Surging Rush _start
@@ -141,7 +141,7 @@ function mod:EruptingWaters(args)
 end
 
 function mod:EruptingWatersRemoved(args)
-	self:Message2("stages", "cyan", CL.over:format(CL.intermission))
+	self:Message2("stages", "cyan", CL.over:format(CL.intermission), false)
 	self:PlaySound("stages", "long")
 	self:Bar(264560, 9.5) -- Choking Brine _success
 	self:Bar(264101, 15.5) -- Surging Rush _start

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -143,10 +143,24 @@ do
 	end
 end
 
-function mod:GraspFromTheDepths(args)
-	self:TargetMessage2(args.spellId, "orange", args.destName)
-	self:PlaySound(args.spellId, "info")
-	self:Bar(args.spellId, 32)
+do
+	local prev = 0
+	local playerList = mod:NewTargetList()
+	function mod:GraspFromTheDepths(args)
+		local t = args.time
+		if t-prev > 6 then
+			prev = t
+			self:Bar(args.spellId, 32)
+		end
+		if stage == 1 then
+			self:TargetMessage2(args.spellId, "orange", args.destName)
+			self:PlaySound(args.spellId, "info")
+		else
+			playerList[#playerList+1] = args.destName
+			self:TargetsMessage(args.spellId, "orange", playerList, 3)
+			self:PlaySound(args.spellId, "info", nil, playerList)
+		end
+	end
 end
 
 function mod:EruptingWaters(args)

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -9,6 +9,12 @@ mod:RegisterEnableMob(134056, 139737) -- Aqu'sirr, Stormsong (for warmup timer)
 mod.engageId = 2130
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local stage = 1
+
+--------------------------------------------------------------------------------
 -- Localization
 --
 
@@ -113,15 +119,26 @@ end
 
 do
 	local prev = 0
+	local playerList = mod:NewTargetList()
 	function mod:Undertow(args)
 		local t = args.time
 		if t-prev > 6 then
 			prev = t
 			self:Bar(264166, 32)
 		end
-		self:TargetMessage2(264166, "orange", args.destName)
-		if self:Me(args.destGUID) then
-			self:PlaySound(264166, "warning")
+		if stage == 1 then
+			self:TargetMessage2(264166, "orange", args.destName)
+			if self:Healer() or self:Me(args.destGUID) then
+				self:PlaySound(264166, "warning")
+			end
+		else
+			playerList[#playerList+1] = args.destName
+			self:TargetsMessage(264166, "orange", playerList, 3)
+			if self:Healer() then
+				self:PlaySound(264166, "warning", nil, playerList)
+			elseif self:Me(args.destGUID) then
+				self:PlaySound(264166, "warning")
+			end
 		end
 	end
 end
@@ -133,6 +150,7 @@ function mod:GraspFromTheDepths(args)
 end
 
 function mod:EruptingWaters(args)
+	stage = 2
 	self:Message2("stages", "cyan", CL.intermission, false)
 	self:PlaySound("stages", "long", "intermission")
 	self:Bar(264560, 13.5) -- Choking Brine _success
@@ -142,6 +160,7 @@ function mod:EruptingWaters(args)
 end
 
 function mod:EruptingWatersRemoved(args)
+	stage = 1
 	self:Message2("stages", "cyan", CL.over:format(CL.intermission), false)
 	self:PlaySound("stages", "long")
 	self:Bar(264560, 9.5) -- Choking Brine _success

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -82,7 +82,7 @@ do
 		local t = args.time
 		if t-prev > 6 then
 			prev = t
-			self:Bar(args.spellId, 32)
+			self:CDBar(args.spellId, 32)
 		end
 	end
 end
@@ -102,7 +102,7 @@ do
 			prev = t
 			self:Message2(args.spellId, "yellow")
 			self:PlaySound(args.spellId, "alert")
-			self:Bar(args.spellId, 32)
+			self:CDBar(args.spellId, 30)
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -79,7 +79,7 @@ do
 		if t-prev > 2 then
 			prev = t
 			self:Message2(args.spellId, "yellow")
-			--self:Bar(args.spellId, 32) XXX Need more info
+			self:Bar(args.spellId, 32)
 		end
 	end
 end
@@ -99,7 +99,7 @@ do
 			prev = t
 			self:Message2(args.spellId, "yellow")
 			self:PlaySound(args.spellId, "alert")
-			--self:Bar(args.spellId, 32) XXX Need more info
+			self:Bar(args.spellId, 32)
 		end
 	end
 end
@@ -114,7 +114,7 @@ do
 			if self:Me(args.destGUID) then
 				self:PlaySound(264166, "warning")
 			end
-			--self:Bar(264166, 32) XXX Need more info
+			self:Bar(264166, 32)
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -68,7 +68,7 @@ do
 	local prev = 0
 	function mod:SeaBlast(args)
 		local t = args.time
-		if t-prev > 2 then
+		if t-prev > 6 then
 			prev = t
 			self:Message2(args.spellId, "orange")
 			self:PlaySound(args.spellId, "alarm")
@@ -80,7 +80,7 @@ do
 	local prev = 0
 	function mod:ChokingBrine(args)
 		local t = args.time
-		if t-prev > 10 then
+		if t-prev > 6 then
 			prev = t
 			self:Bar(args.spellId, 32)
 		end
@@ -98,7 +98,7 @@ do
 	local prev = 0
 	function mod:SurgingRush(args)
 		local t = args.time
-		if t-prev > 2 then
+		if t-prev > 6 then
 			prev = t
 			self:Message2(args.spellId, "yellow")
 			self:PlaySound(args.spellId, "alert")
@@ -111,7 +111,7 @@ do
 	local prev = 0
 	function mod:Undertow(args)
 		local t = args.time
-		if t-prev > 10 then
+		if t-prev > 6 then
 			prev = t
 			self:Bar(264166, 32)
 		end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -91,7 +91,7 @@ do
 	local playerList = mod:NewTargetList()
 	function mod:ChokingBrineApplied(args)
 		if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
-			self:TargetsMessage(264560, "yellow", playerList, 3)
+			self:TargetsMessage(264560, "yellow", playerList, 5)
 			self:PlaySound(264560, "alarm", nil, playerList)
 		end
 	end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -40,7 +40,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "ChokingBrine", 264560)
 	self:Log("SPELL_AURA_APPLIED", "ChokingBrineApplied", 264560, 264773) -- Initial, Ground Pickup
 	self:Log("SPELL_CAST_START", "SurgingRush", 264101)
-	self:Log("SPELL_CAST_SUCCESS", "Undertow", 264166, 264144)
+	self:Log("SPELL_CAST_SUCCESS", "Undertow", 264166, 264144, 265366)
 	self:Log("SPELL_CAST_START", "EruptingWaters", 264903)
 	self:Log("SPELL_AURA_REMOVED", "EruptingWatersRemoved", 264903)
 	self:Log("SPELL_AURA_APPLIED", "GraspFromTheDepths", 264526)
@@ -111,13 +111,13 @@ do
 	local prev = 0
 	function mod:Undertow(args)
 		local t = args.time
-		if t-prev > 2 then
+		if t-prev > 10 then
 			prev = t
-			self:TargetMessage2(264166, "orange", args.destName)
-			if self:Me(args.destGUID) then
-				self:PlaySound(264166, "warning")
-			end
 			self:Bar(264166, 32)
+		end
+		self:TargetMessage2(264166, "orange", args.destName)
+		if self:Me(args.destGUID) then
+			self:PlaySound(264166, "warning")
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -29,6 +29,7 @@ function mod:GetOptions()
 		264101, -- Surging Rush
 		264166, -- Undertow
 		264903, -- Erupting Waters
+		264526, -- Grasp from the Depths
 	}
 end
 
@@ -41,6 +42,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "SurgingRush", 264101)
 	self:Log("SPELL_CAST_SUCCESS", "Undertow", 264166, 264144)
 	self:Log("SPELL_CAST_START", "EruptingWaters", 264903)
+	self:Log("SPELL_AURA_APPLIED", "GraspFromTheDepths", 264526)
 end
 
 function mod:OnEngage()
@@ -117,6 +119,11 @@ do
 			self:Bar(264166, 32)
 		end
 	end
+end
+
+function mod:GraspFromTheDepths(args)
+	self:TargetMessage2(args.spellId, "orange", args.destName)
+	self:PlaySound(args.spellId, "info")
 end
 
 function mod:EruptingWaters(args)

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -26,7 +26,7 @@ function mod:GetOptions()
 		"warmup",
 		"stages",
 		265001, -- Sea Blast
-		264560, -- Choking Brine
+		{264560, "DISPEL"}, -- Choking Brine
 		264101, -- Surging Rush
 		264166, -- Undertow
 		264526, -- Grasp from the Depths
@@ -82,15 +82,14 @@ do
 		local t = args.time
 		if t-prev > 2 then
 			prev = t
-			self:Message2(args.spellId, "yellow")
 			self:Bar(args.spellId, 32)
 		end
 	end
 end
 
 function mod:ChokingBrineApplied(args)
-	if self:Me(args.destGUID) then
-		self:PersonalMessage(264560)
+	if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
+		self:TargetMessage2(264560, "yellow", args.destName)
 		self:PlaySound(264560, "alarm")
 	end
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -91,6 +91,7 @@ do
 	local playerList = mod:NewTargetList()
 	function mod:ChokingBrineApplied(args)
 		if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
+			playerList[#playerList+1] = args.destName
 			self:TargetsMessage(264560, "yellow", playerList, 5)
 			self:PlaySound(264560, "alarm", nil, playerList)
 		end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -87,10 +87,13 @@ do
 	end
 end
 
-function mod:ChokingBrineApplied(args)
-	if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
-		self:TargetMessage2(264560, "yellow", args.destName)
-		self:PlaySound(264560, "alarm")
+do
+	local playerList = mod:NewTargetList()
+	function mod:ChokingBrineApplied(args)
+		if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
+			self:TargetsMessage(264560, "yellow", playerList, 3)
+			self:PlaySound(264560, "alarm", nil, playerList)
+		end
 	end
 end
 

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -53,7 +53,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:Bar(264560, 9.5) -- Choking Brine _success
+	self:Bar(264560, 10.2) -- Choking Brine _success
 	self:Bar(264101, 15.5) -- Surging Rush _start
 	self:Bar(264526, 24) -- Grasp from the Depths _success
 	self:Bar(264166, 32) -- Undertow _success

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -24,11 +24,11 @@ end
 function mod:GetOptions()
 	return {
 		"warmup",
+		"stages",
 		265001, -- Sea Blast
 		264560, -- Choking Brine
 		264101, -- Surging Rush
 		264166, -- Undertow
-		264903, -- Erupting Waters
 		264526, -- Grasp from the Depths
 	}
 end
@@ -42,12 +42,14 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "SurgingRush", 264101)
 	self:Log("SPELL_CAST_SUCCESS", "Undertow", 264166, 264144)
 	self:Log("SPELL_CAST_START", "EruptingWaters", 264903)
+	self:Log("SPELL_AURA_REMOVED", "EruptingWatersRemoved", 264903)
 	self:Log("SPELL_AURA_APPLIED", "GraspFromTheDepths", 264526)
 end
 
 function mod:OnEngage()
-	self:Bar(264560, 12) -- Choking Brine _success
+	self:Bar(264560, 9.5) -- Choking Brine _success
 	self:Bar(264101, 15.5) -- Surging Rush _start
+	self:Bar(264526, 24) -- Grasp from the Depths _success
 	self:Bar(264166, 32) -- Undertow _success
 end
 
@@ -128,10 +130,19 @@ function mod:GraspFromTheDepths(args)
 end
 
 function mod:EruptingWaters(args)
-	self:Message2(args.spellId, "cyan")
-	self:PlaySound(args.spellId, "long", "intermission")
+	self:Message2("stages", "cyan", CL.intermission)
+	self:PlaySound("stages", "long", "intermission")
 	self:Bar(264560, 13.5) -- Choking Brine _success
 	self:Bar(264101, 18.5) -- Surging Rush _start
 	self:Bar(264166, 28.5) -- Undertow _success
-	self:Bar(264526, 38) -- Grasp from the Depths _applied
+	self:Bar(264526, 32) -- Grasp from the Depths _applied
+end
+
+function mod:EruptingWatersRemoved(args)
+	self:Message2("stages", "cyan", CL.over:format(CL.intermission))
+	self:PlaySound("stages", "long")
+	self:Bar(264560, 9.5) -- Choking Brine _success
+	self:Bar(264101, 15.5) -- Surging Rush _start
+	self:Bar(264526, 24) -- Grasp from the Depths _success
+	self:Bar(264166, 32) -- Undertow _success
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -68,7 +68,7 @@ do
 	local prev = 0
 	function mod:SeaBlast(args)
 		local t = args.time
-		if t-prev > 6 then
+		if t-prev > 2 then
 			prev = t
 			self:Message2(args.spellId, "orange")
 			self:PlaySound(args.spellId, "alarm")

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -97,10 +97,13 @@ end
 do
 	local playerList = mod:NewTargetList()
 	function mod:ChokingBrineApplied(args)
-		if self:Dispeller("magic", nil, 264560) or self:Me(args.destGUID) then
+		if self:Dispeller("magic", nil, 264560) then
 			playerList[#playerList+1] = args.destName
 			self:TargetsMessage(264560, "yellow", playerList, 5)
 			self:PlaySound(264560, "alarm", nil, playerList)
+		elseif self:Me(args.destGUID) then
+			self:PersonalMessage(264560)
+			self:PlaySound(264560, "alarm")
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -53,6 +53,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	stage = 1
 	self:Bar(264560, 10.2) -- Choking Brine _success
 	self:Bar(264101, 15.5) -- Surging Rush _start
 	self:Bar(264526, 24) -- Grasp from the Depths _success

--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -124,6 +124,7 @@ end
 function mod:GraspFromTheDepths(args)
 	self:TargetMessage2(args.spellId, "orange", args.destName)
 	self:PlaySound(args.spellId, "info")
+	self:Bar(args.spellId, 32)
 end
 
 function mod:EruptingWaters(args)
@@ -132,4 +133,5 @@ function mod:EruptingWaters(args)
 	self:Bar(264560, 13.5) -- Choking Brine _success
 	self:Bar(264101, 18.5) -- Surging Rush _start
 	self:Bar(264166, 28.5) -- Undertow _success
+	self:Bar(264526, 38) -- Grasp from the Depths _applied
 end

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -15,7 +15,6 @@ mod.engageId = 2131
 function mod:GetOptions()
 	return {
 		267891, -- Swiftness Ward
-		--267830, -- Blessing of the Tempest XXX Was not in normal?
 		267818, -- Slicing Blast
 		267905, -- Reinforcing Ward
 		{267901, "TANK"}, -- Blessing of Ironsides
@@ -26,7 +25,6 @@ end
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "SwiftnessWard", 267891)
 	self:Log("SPELL_AURA_APPLIED", "SwiftnessWardApplied", 267888)
-	--self:Log("SPELL_CAST_SUCCESS", "BlessingoftheTempest", 267830)
 	self:Log("SPELL_CAST_START", "SlicingBlast", 267818)
 	self:Log("SPELL_CAST_START", "ReinforcingWard", 267905)
 	self:Log("SPELL_CAST_START", "BlessingofIronsides", 267901)
@@ -55,12 +53,6 @@ function mod:SwiftnessWardApplied(args)
 		self:PlaySound(267891, "info")
 	end
 end
-
--- function mod:BlessingoftheTempest(args)
--- 	self:Message2(args.spellId, "orange")
--- 	self:PlaySound(args.spellId, "warning")
--- 	self:CastBar(args.spellId, 11)
--- end
 
 function mod:SlicingBlast(args)
 	self:Message2(args.spellId, "yellow")

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -18,7 +18,7 @@ function mod:GetOptions()
 		--267830, -- Blessing of the Tempest XXX Was not in normal?
 		267818, -- Slicing Blast
 		267905, -- Reinforcing Ward
-		--{267901, "TANK"}, -- Blessing of Ironsides XXX Not used in normal?
+		{267901, "TANK"}, -- Blessing of Ironsides
 		{267899, "TANK"}, -- Hindering Cleave
 	}
 end
@@ -29,7 +29,7 @@ function mod:OnBossEnable()
 	--self:Log("SPELL_CAST_SUCCESS", "BlessingoftheTempest", 267830)
 	self:Log("SPELL_CAST_START", "SlicingBlast", 267818)
 	self:Log("SPELL_CAST_START", "ReinforcingWard", 267905)
-	--self:Log("SPELL_CAST_START", "BlessingofIronsides", 267901)
+	self:Log("SPELL_CAST_START", "BlessingofIronsides", 267901)
 	self:Log("SPELL_CAST_START", "HinderingCleave", 267899)
 end
 
@@ -75,11 +75,11 @@ function mod:ReinforcingWard(args)
 	self:Bar(args.spellId, 30)
 end
 
--- function mod:BlessingofIronsides(args)
--- 	self:Message2(args.spellId, "red")
--- 	self:PlaySound(args.spellId, "warning")
--- 	self:CastBar(args.spellId, 8)
--- end
+function mod:BlessingofIronsides(args)
+	self:Message2(args.spellId, "red")
+	self:PlaySound(args.spellId, "warning")
+	self:CastBar(args.spellId, 8)
+end
 
 function mod:HinderingCleave(args)
 	self:Message2(args.spellId, "yellow")

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -70,6 +70,7 @@ end
 function mod:BlessingofIronsides(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
+	self:Bar(args.spellId, 33)
 	self:CastBar(args.spellId, 8)
 end
 

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -28,6 +28,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "SlicingBlast", 267818)
 	self:Log("SPELL_CAST_START", "ReinforcingWard", 267905)
 	self:Log("SPELL_CAST_START", "BlessingofIronsides", 267901)
+	self:Log("SPELL_AURA_APPLIED", "BlessingofIronsidesApplied", 267901)
 	self:Log("SPELL_CAST_START", "HinderingCleave", 267899)
 end
 
@@ -71,7 +72,10 @@ function mod:BlessingofIronsides(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
 	self:Bar(args.spellId, 33)
-	self:CastBar(args.spellId, 8)
+end
+
+function mod:BlessingofIronsidesApplied(args)
+	self:TargetBar(args.spellId, 8, args.destName)
 end
 
 function mod:HinderingCleave(args)

--- a/BfA/ShrineOfTheStorm/Options/Colors.lua
+++ b/BfA/ShrineOfTheStorm/Options/Colors.lua
@@ -2,20 +2,23 @@
 BigWigs:AddColors("Aqu'sirr", {
 	[264101] = "yellow",
 	[264166] = {"blue","orange"},
+	[264526] = {"blue","orange"},
 	[264560] = {"blue","yellow"},
-	[264903] = "cyan",
 	[265001] = "orange",
+	["stages"] = "cyan",
 })
 
 BigWigs:AddColors("Tidesage Coucil", {
 	[267818] = "yellow",
 	[267891] = {"cyan","green"},
 	[267899] = "yellow",
+	[267901] = "red",
 	[267905] = "cyan",
 })
 
 BigWigs:AddColors("Lord Stormsong", {
 	[268347] = "yellow",
+	[268896] = {"blue","orange"},
 	[269097] = "orange",
 	[269131] = {"blue","red"},
 })

--- a/BfA/ShrineOfTheStorm/Options/Sounds.lua
+++ b/BfA/ShrineOfTheStorm/Options/Sounds.lua
@@ -2,20 +2,23 @@
 BigWigs:AddSounds("Aqu'sirr", {
 	[264101] = "alert",
 	[264166] = "warning",
+	[264526] = "info",
 	[264560] = "alarm",
-	[264903] = "long",
 	[265001] = "alarm",
+	["stages"] = "long",
 })
 
 BigWigs:AddSounds("Tidesage Coucil", {
 	[267818] = "alert",
 	[267891] = {"info","long"},
 	[267899] = "alert",
+	[267901] = "warning",
 	[267905] = "long",
 })
 
 BigWigs:AddSounds("Lord Stormsong", {
 	[268347] = "alert",
+	[268896] = "alert",
 	[269097] = "alarm",
 	[269131] = "warning",
 })

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -28,7 +28,7 @@ function mod:GetOptions()
 		268347, -- Void Bolt
 		269097, -- Waken the Void
 		269131, -- Ancient Mindbender
-		268896, -- Mind Rend
+		{268896, "DISPEL"}, -- Mind Rend
 	}
 end
 

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -28,6 +28,7 @@ function mod:GetOptions()
 		268347, -- Void Bolt
 		269097, -- Waken the Void
 		269131, -- Ancient Mindbender
+		268896, -- Mind Rend
 	}
 end
 
@@ -38,6 +39,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "WakentheVoid", 269097)
 	self:Log("SPELL_CAST_SUCCESS", "AncientMindbender", 269131)
 	self:Log("SPELL_AURA_APPLIED", "AncientMindbenderApplied", 269131)
+	self:Log("SPELL_AURA_APPLIED", "MindRendApplied", 268896)
 end
 
 function mod:OnEngage()
@@ -80,4 +82,11 @@ end
 function mod:AncientMindbenderApplied(args)
 	self:TargetMessage2(args.spellId, "red", args.destName)
 	self:PlaySound(args.spellId, "warning", nil, args.destName)
+end
+
+function mod:MindRendApplied(args)
+	if self:Dispeller("magic", nil, args.spellId) or self:Me(args.destGUID) then
+		self:TargetMessage2(args.spellId, "orange", args.destName)
+		self:PlaySound(args.spellId, "alert")
+	end
 end


### PR DESCRIPTION
**Aqusirr**
- Add stage messages
- Add timer for Choking Brine, Surging Rush, Undertow, and Grasp from the Depths
- Improve target messages

**Council**
- Add Blessing of Ironsides timer and message

**Stormsong**
- Add Mind Rend target message