### PR TITLE
BfA/SiegeOfBoralus: Improve boss timers and messages

### DIFF
--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -24,7 +24,6 @@ if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
 	L.remaining = "%s, %d remaining"
-	L.used_remaining = "%s used, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -117,7 +116,7 @@ function mod:HeavyOrdnance(args)
 		self:StopBar(barText)
 		self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
-	self:Message2(277965, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
+	self:Message2(277965, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
 	self:PlaySound(277965, "info")
 end
 

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -108,16 +108,23 @@ function mod:SteelTempest(args)
 	self:PlaySound(args.spellId, "alarm")
 end
 
-function mod:HeavyOrdnance(args)
-	local barText = CL.count:format(args.spellName, bombsRemaining)
-	bombsRemaining = bombsRemaining - 1
-	local timer = self:BarTimeLeft(barText)
-	if timer and bombsRemaining > 0 then
-		self:StopBar(barText)
-		self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
+do
+	local prev = 0
+	function mod:HeavyOrdnance(args)
+		local t = args.time
+		if t ~= prev then
+			prev = t
+			local barText = CL.count:format(args.spellName, bombsRemaining)
+			bombsRemaining = bombsRemaining - 1
+			local timer = self:BarTimeLeft(barText)
+			if timer and bombsRemaining > 0 then
+				self:StopBar(barText)
+				self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
+			end
+			self:Message2(277965, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
+			self:PlaySound(277965, "info")
+		end
 	end
-	self:Message2(277965, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
-	self:PlaySound(277965, "info")
 end
 
 function mod:HeavyOrdnanceApplied(args)

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -76,7 +76,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
-		self:Bar(277965, 45, CL.count:format(self:SpellName(277965), bombsRemaining)) -- Heavy Ordnance
+		self:Bar(277965, 42, CL.count:format(self:SpellName(277965), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
 		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 		self:PlaySound("adds", "long")
@@ -112,7 +112,7 @@ function mod:HeavyOrdnance(args)
 	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
 	local timer = self:BarTimeLeft(barText)
-	if timer then
+	if timer and bombsRemaining > 0 then
 		self:StopBar(barText)
 		self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
@@ -124,7 +124,7 @@ function mod:HeavyOrdnanceApplied(args)
 	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
 	local timer = self:BarTimeLeft(barText)
-	if timer then
+	if timer and bombsRemaining > 0 then
 		self:StopBar(barText)
 		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
 	end

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 17, CL.adds, L.adds_icon)
+	self:CDBar("adds", 33.1, CL.adds, L.adds_icon)
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -75,11 +75,14 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		bombsRemaining = 3
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
-		self:Bar(257585, 60)
+		self:CDBar(257585, 60)
 		self:Bar(277965, 42, CL.count:format(self:SpellName(277965), bombsRemaining)) -- Heavy Ordnance
-	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
-		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
-		self:PlaySound("adds", "long")
+	elseif spellId == 274002 then -- Call Adds
+		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
+		if hp > 33 then -- Spams every second under 33% but doesn't actually span adds
+			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
+			self:PlaySound("adds", "long")
+		end
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -23,7 +23,8 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
-	L.remaining = "%s (%d remaining)"
+	L.remaining = "%s, %d remaining"
+	L.used_remaining = "%s used, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -109,7 +110,7 @@ end
 
 function mod:HeavyOrdnance(args)
 	bombsRemaining = bombsRemaining - 1
-	self:Message2(277965, "orange", L.remaining:format(self:SpellName(277965), bombsRemaining))
+	self:Message2(277965, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
 	self:PlaySound(277965, "info")
 end
 

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "IronGazeRemoved", 260954)
 	self:Log("SPELL_AURA_APPLIED", "HangmansNoose", 261428)
 	self:Log("SPELL_CAST_START", "SteelTempest", 260924)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720)
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280933) -- Damage to player, damage to add
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 277965)
 end
 

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -66,12 +66,9 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
-	elseif spellId == 274002 then -- Call Adds
-		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-		if hp > 33 then -- Low CD under 33%
-			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
-			self:PlaySound("adds", "long")
-		end
+	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
+		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
+		self:PlaySound("adds", "long")
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "IronGazeRemoved", 260954)
 	self:Log("SPELL_AURA_APPLIED", "HangmansNoose", 261428)
 	self:Log("SPELL_CAST_START", "SteelTempest", 260924)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280933) -- Damage to player, damage to add
+	self:Log("SPELL_DAMAGE", "HeavyOrdnanceDamage", 273720, 280933) -- Damage to player, damage to add
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 277965)
 end
 
@@ -79,7 +79,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Bar(277965, 42, CL.count:format(self:SpellName(277965), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 then -- Call Adds
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-		if hp > 33 then -- Spams every second under 33% but doesn't actually span adds
+		if hp > 33 then -- Spams every second under 33% but doesn't actually spawn adds
 			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 			self:PlaySound("adds", "long")
 		end
@@ -113,7 +113,7 @@ end
 
 do
 	local prev = 0
-	function mod:HeavyOrdnance(args)
+	function mod:HeavyOrdnanceDamage(args)
 		local t = args.time
 		if t ~= prev then
 			prev = t

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -23,7 +23,8 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
-	L.remaining = "%s, %d remaining"
+	L.remaining = "%s on %s, %d remaining"
+	L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -124,7 +125,7 @@ do
 				self:StopBar(barText)
 				self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
 			end
-			self:Message2(277965, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
+			self:Message2(277965, "orange", L.remaining:format(args.spellName, args.destName, bombsRemaining))
 			self:PlaySound(277965, "info")
 		end
 	end
@@ -138,7 +139,7 @@ function mod:HeavyOrdnanceApplied(args)
 		self:StopBar(barText)
 		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
-	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
+	self:Message2(args.spellId, "green", L.remaining_boss:format(args.spellName, bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -101,7 +101,7 @@ function mod:SteelTempest(args)
 end
 
 function mod:HeavyOrdnance(args)
-	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName)) -- XXX Check if this does not mean it's also on adds
+	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -67,12 +67,10 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:PlaySound(257585, "warning")
 		self:CDBar(257585, 60) -- XXX Double check
 	elseif spellId == 274002 then -- Call Adds
-		self:StopBar(CL.adds)
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
 		if hp > 33 then -- Low CD under 33%
 			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 			self:PlaySound("adds", "long")
-			self:CDBar("adds", 17, CL.adds, L.adds_icon) -- XXX Double check
 		end
 	end
 end

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-
+	self:Bar(257585, 10) -- Cannon Barrage
 end
 
 --------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 	if spellId == 257540 then -- Cannon Barrage
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
-		self:CDBar(257585, 60) -- XXX Double check
+		self:Bar(257585, 60)
 	elseif spellId == 274002 then -- Call Adds
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
 		if hp > 33 then -- Low CD under 33%

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 33.1, CL.adds, L.adds_icon)
+	self:CDBar("adds", 17, CL.adds, L.adds_icon)
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 17, CL.adds, L.adds_icon)
+
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -77,6 +77,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
+		self:Bar(277965, 45, CL.count:format(self:SpellName(277965), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
 		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 		self:PlaySound("adds", "long")
@@ -109,13 +110,25 @@ function mod:SteelTempest(args)
 end
 
 function mod:HeavyOrdnance(args)
+	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
+	local timer = self:BarTimeLeft(barText)
+	if timer then
+		self:StopBar(barText)
+		self:Bar(277965, timer, CL.count:format(args.spellName, bombsRemaining))
+	end
 	self:Message2(277965, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
 	self:PlaySound(277965, "info")
 end
 
 function mod:HeavyOrdnanceApplied(args)
+	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
+	local timer = self:BarTimeLeft(barText)
+	if timer then
+		self:StopBar(barText)
+		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
+	end
 	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -10,6 +10,12 @@ mod:RegisterEnableMob(128649) -- Sergeant Bainbridge
 mod.engageId = 2097
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local bombsRemaining = 0
+
+--------------------------------------------------------------------------------
 -- Localization
 --
 
@@ -17,6 +23,7 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
+	L.remaining = "%s (%d remaining)"
 end
 
 --------------------------------------------------------------------------------
@@ -43,10 +50,12 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "IronGazeRemoved", 260954)
 	self:Log("SPELL_AURA_APPLIED", "HangmansNoose", 261428)
 	self:Log("SPELL_CAST_START", "SteelTempest", 260924)
-	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnance", 277965)
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720)
+	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 277965)
 end
 
 function mod:OnEngage()
+	bombsRemaining = 0
 	self:Bar(257585, 11) -- Cannon Barrage
 end
 
@@ -63,6 +72,7 @@ end
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 	if spellId == 257540 then -- Cannon Barrage
+		bombsRemaining = 3
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
@@ -98,7 +108,14 @@ function mod:SteelTempest(args)
 end
 
 function mod:HeavyOrdnance(args)
-	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName))
+	bombsRemaining = bombsRemaining - 1
+	self:Message2(277965, "orange", L.remaining:format(self:SpellName(277965), bombsRemaining))
+	self:PlaySound(277965, "info")
+end
+
+function mod:HeavyOrdnanceApplied(args)
+	bombsRemaining = bombsRemaining - 1
+	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:Bar(257585, 10) -- Cannon Barrage
+	self:Bar(257585, 11) -- Cannon Barrage
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Darkfathom.lua
+++ b/BfA/SiegeOfBoralus/Darkfathom.lua
@@ -29,8 +29,8 @@ end
 
 function mod:OnEngage()
 	self:CDBar(257882, 7) -- Break Water
-	self:CDBar(261563, 13) -- Crashing Tide
-	self:CDBar(276068, 24) -- Tidal Surge
+	self:CDBar(261563, 12.5) -- Crashing Tide
+	self:CDBar(276068, 23.5) -- Tidal Surge
 end
 
 --------------------------------------------------------------------------------
@@ -41,7 +41,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 257861 then -- Crashing Tide
 		self:Message2(261563, "yellow")
 		self:PlaySound(261563, "alert")
-		self:CDBar(261563, 17)
+		self:CDBar(261563, 16)
 	end
 end
 
@@ -49,6 +49,7 @@ function mod:BreakWater(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm")
 	self:CDBar(args.spellId, 26)
+	self:CastBar(args.spellId, 4.6)
 end
 
 function mod:TidalSurge(args)

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "deDE")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Vorhut von Kul Tiras"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "deDE")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "deDE")
 if L then
 	L.demolishing_desc = "Warnungen und Timer für das Erscheinen des Verwüstenden Schreckens."

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Hellebardier von Kul Tiras"
 	L.raider = "Eisenfluträuber"
 	L.vanguard = "Vorhut von Kul Tiras"
+	L.marksman = "Schütze von Kul Tiras"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "deDE")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "deDE")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "esES") or BigWigs:NewBossLocale("Chopper Redhook", "esMX")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "esES") or BigWigs:NewBossLocale("Viq'Goth", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Alabardero de Kul Tiras"
 	L.raider = "Asaltante Marea de Hierro"
 	L.vanguard = "Vanguardia de Kul Tiras"
+	L.marksman = "Tirador de Kul Tiras"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Vanguardia de Kul Tiras"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "esES") or BigWigs:NewBossLocale("Chopper Redhook", "esMX")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "esES") or BigWigs:NewBossLocale("Viq'Goth", "esMX")
 if L then
 	L.demolishing_desc = "Alertas y temporizadores para cuando aparece el Terror demoledor."

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "esES") or BigWigs:NewBossLocale("Chopper Redhook", "esMX")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "esES") or BigWigs:NewBossLocale("Viq'Goth", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "esES") or BigWigs:NewBossLocale("Chopper Redhook", "esMX")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "esES") or BigWigs:NewBossLocale("Viq'Goth", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "frFR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Avant-garde de Kul Tiras"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "frFR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "frFR")
 if L then
 	-- L.demolishing_desc = "Warnings and timers for when the Demolishing Terror spawns."

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Hallebardier kultirassien"
 	L.raider = "Ecumeur des Lamineurs"
 	L.vanguard = "Avant-garde de Kul Tiras"
+	L.marksman = "Tireur d'élite de Kul Tiras"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "frFR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "frFR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "itIT")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "itIT")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "itIT")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Avanguardia di Kul Tiras"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "itIT")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "itIT")
 if L then
 	-- L.demolishing_desc = "Warnings and timers for when the Demolishing Terror spawns."

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Alabardiere di Kul Tiras"
 	L.raider = "Incursore Marferreo"
 	L.vanguard = "Avanguardia di Kul Tiras"
+	L.marksman = "Tiratore di Kul Tiras"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "koKR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "쿨 티란 미늘창"
 	L.raider = "무쇠파도 약탈단"
 	L.vanguard = "쿨 티란 선봉대원"
+	L.marksman = "쿨 티란 명사수"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "koKR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "쿨 티란 선봉대원"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "koKR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "koKR")
 if L then
 	-- L.demolishing_desc = "Warnings and timers for when the Demolishing Terror spawns."

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "koKR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Vanguarda Kultirena"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "ptBR")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "ptBR")
 if L then
 	-- L.demolishing_desc = "Warnings and timers for when the Demolishing Terror spawns."

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ptBR")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ptBR")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Alabardeiro Kultireno"
 	L.raider = "Saqueador Maré-férrea"
 	L.vanguard = "Vanguarda Kultirena"
+	L.marksman = "Atirador Perito Kultireno"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ptBR")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ruRU")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "Кул-тирасский стражник"
 	L.raider = "Налетчик из братства Стальных Волн"
 	L.vanguard = "Кул-тирасский боец авангарда"
+	L.marksman = "Кул-тирасский стрелок"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ruRU")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "ruRU")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "Кул-тирасский боец авангарда"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "ruRU")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "ruRU")
 if L then
 	-- L.demolishing_desc = "Warnings and timers for when the Demolishing Terror spawns."

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhCN")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhCN")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "库尔提拉斯先锋"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "zhCN")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "zhCN")
 if L then
 	L.demolishing_desc = "当攻城恐魔出现时的警报和计时器。"

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "库尔提拉斯戟兵"
 	L.raider = "铁潮袭击者"
 	L.vanguard = "库尔提拉斯先锋"
+	L.marksman = "库尔提拉斯神射手"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhCN")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -13,6 +13,16 @@ if L then
 	L.vanguard = "庫爾提拉斯先鋒"
 end
 
+L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
+L = BigWigs:NewBossLocale("Chopper Redhook", "zhTW")
+if L then
+	-- L.remaining = "%s (%d remaining)"
+end
+
 L = BigWigs:NewBossLocale("Viq'Goth", "zhTW")
 if L then
 	L.demolishing_desc = "為滅擊觸鬚的出現顯示警告與計時。"

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -11,6 +11,7 @@ if L then
 	L.halberd = "庫爾提拉斯長戟兵"
 	L.raider = "鐵潮劫掠者"
 	L.vanguard = "庫爾提拉斯先鋒"
+	-- L.marksman = "Kul Tiran Marksman"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -16,13 +16,11 @@ end
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhTW")
 if L then
 	-- L.remaining = "%s, %d remaining"
-	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhTW")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -16,12 +16,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhTW")
 if L then
-	-- L.remaining = "%s, %d remaining"
+	-- L.remaining = "%s on %s, %d remaining"
+	-- L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhTW")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -15,12 +15,14 @@ end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Chopper Redhook", "zhTW")
 if L then
-	-- L.remaining = "%s (%d remaining)"
+	-- L.remaining = "%s, %d remaining"
+	-- L.used_remaining = "%s used, %d remaining"
 end
 
 L = BigWigs:NewBossLocale("Viq'Goth", "zhTW")

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -83,7 +83,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 			self:Message2(268752, "green", CL.over:format(self:SpellName(268752)))
 			self:PlaySound(268752, "long")
 
-			self:Bar(269029, 3) -- Clear the Deck
+			self:Bar(269029, 7) -- Clear the Deck
 			self:Bar(268752, 35.7) -- Withdraw
 		end
 	elseif spellId == 268963 then -- Unstable Ordnance (Dropped)

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -50,8 +50,8 @@ end
 
 function mod:OnEngage()
 	withdrawn = 0
-	self:CDBar(269029, 4.5) -- Clear the Deck
-	self:CDBar(268752, 13.5) -- Withdraw
+	self:CDBar(269029, 3.5) -- Clear the Deck
+	self:Bar(268752, 12.1) -- Withdraw
 end
 
 --------------------------------------------------------------------------------
@@ -62,6 +62,7 @@ function mod:UNIT_SPELLCAST_START(_, _, _, spellId)
 	if spellId == 268260 then -- Broadside
 		self:Message2(spellId, "orange")
 		self:PlaySound(spellId, "alarm")
+		self:Bar(268260, 12) -- Broadside
 	end
 end
 
@@ -74,14 +75,14 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		self:StopBar(269029) -- Clear the Deck
 		self:StopBar(268752) -- Withdraw
 
-		self:CDBar(268260, 16) -- Broadside
+		self:Bar(268260, 11.2) -- Broadside
 	elseif spellId == 268745 then -- Energy Tracker / Jump Back
 		if withdrawn == 1 then
 			self:Message2(268752, "green", CL.over:format(self:SpellName(268752)))
 			self:PlaySound(268752, "long")
 
-			self:CDBar(269029, 7) -- Clear the Deck
-			self:Bar(268752, 36) -- Withdraw
+			self:CDBar(269029, 3) -- Clear the Deck
+			self:Bar(268752, 35.7) -- Withdraw
 		end
 	elseif spellId == 268963 then -- Unstable Ordnance (Dropped)
 		self:Message2(spellId, "cyan", L.ordanance_dropped)

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -109,7 +109,6 @@ do
 			prev = t
 			self:Message2(args.spellId, "purple")
 			self:PlaySound(args.spellId, "alarm")
-			self:CDBar(args.spellId, 9)
 		end
 	end
 end

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -33,7 +33,7 @@ function mod:GetOptions()
 		272471, -- Evasive
 		269029, -- Clear the Deck
 		268752, -- Withdraw
-		268230, -- Crimson Swipe
+		{268230, "TANK"}, -- Crimson Swipe
 		268260, -- Broadside
 		268963, -- Unstable Ordnance
 		273470, -- Gut Shot
@@ -107,7 +107,7 @@ do
 	local prev = 0
 	function mod:CrimsonSwipe(args)
 		local t = args.time
-		if t-prev > 1.5 then
+		if t-prev > 2 then
 			prev = t
 			self:Message2(args.spellId, "purple")
 			self:PlaySound(args.spellId, "alarm")

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -50,7 +50,7 @@ end
 
 function mod:OnEngage()
 	withdrawn = 0
-	self:CDBar(269029, 3.5) -- Clear the Deck
+	self:Bar(269029, 3.5) -- Clear the Deck
 	self:Bar(268752, 12.1) -- Withdraw
 end
 
@@ -81,7 +81,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 			self:Message2(268752, "green", CL.over:format(self:SpellName(268752)))
 			self:PlaySound(268752, "long")
 
-			self:CDBar(269029, 3) -- Clear the Deck
+			self:Bar(269029, 3) -- Clear the Deck
 			self:Bar(268752, 35.7) -- Withdraw
 		end
 	elseif spellId == 268963 then -- Unstable Ordnance (Dropped)
@@ -98,7 +98,7 @@ end
 function mod:CleartheDeck(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm")
-	self:CDBar(args.spellId, 18)
+	self:Bar(args.spellId, 18)
 end
 
 do

--- a/BfA/SiegeOfBoralus/Lockwood.lua
+++ b/BfA/SiegeOfBoralus/Lockwood.lua
@@ -36,6 +36,7 @@ function mod:GetOptions()
 		268230, -- Crimson Swipe
 		268260, -- Broadside
 		268963, -- Unstable Ordnance
+		273470, -- Gut Shot
 	}
 end
 
@@ -46,6 +47,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "Evasive", 272471)
 	self:Log("SPELL_CAST_START", "CleartheDeck", 269029)
 	self:Log("SPELL_CAST_START", "CrimsonSwipe", 268230)
+	self:Log("SPELL_CAST_SUCCESS", "GutShot", 273470)
 end
 
 function mod:OnEngage()
@@ -111,4 +113,9 @@ do
 			self:PlaySound(args.spellId, "alarm")
 		end
 	end
+end
+
+function mod:GutShot(args)
+	self:TargetMessage2(args.spellId, "red", args.destName)
+	self:PlaySound(args.spellId, "alert")
 end

--- a/BfA/SiegeOfBoralus/Options/Colors.lua
+++ b/BfA/SiegeOfBoralus/Options/Colors.lua
@@ -5,7 +5,7 @@ BigWigs:AddColors("Chopper Redhook", {
 	[257348] = {"blue","red"},
 	[257459] = {"blue","yellow"},
 	[257585] = "orange",
-	[273721] = "green",
+	[273721] = {"green","orange"},
 	["adds"] = "yellow",
 })
 
@@ -14,7 +14,7 @@ BigWigs:AddColors("Sergeant Bainbridge", {
 	[260924] = "orange",
 	[260954] = {"blue","yellow"},
 	[261428] = {"blue","red"},
-	[277965] = "green",
+	[277965] = {"green","orange"},
 	[279761] = "orange",
 	["adds"] = "yellow",
 })
@@ -39,6 +39,7 @@ BigWigs:AddColors("Viq'Goth", {
 	[269266] = "purple",
 	[269366] = "cyan",
 	[270185] = "orange",
+	[270590] = "red",
 	[275014] = {"blue","yellow"},
 	["demolishing"] = "yellow",
 	["stages"] = "green",

--- a/BfA/SiegeOfBoralus/Options/Colors.lua
+++ b/BfA/SiegeOfBoralus/Options/Colors.lua
@@ -51,6 +51,7 @@ BigWigs:AddColors("Siege of Boralus Trash", {
 	[257169] = "red",
 	[257170] = "yellow",
 	[257288] = "orange",
+	[257641] = "blue",
 	[268260] = "orange",
 	[272421] = {"blue","yellow"},
 	[272711] = "orange",

--- a/BfA/SiegeOfBoralus/Options/Colors.lua
+++ b/BfA/SiegeOfBoralus/Options/Colors.lua
@@ -26,6 +26,7 @@ BigWigs:AddColors("Dread Captain Lockwood", {
 	[268963] = "cyan",
 	[269029] = "orange",
 	[272471] = "yellow",
+	[273470] = {"blue","red"},
 })
 
 BigWigs:AddColors("Hadal Darkfathom", {

--- a/BfA/SiegeOfBoralus/Options/Sounds.lua
+++ b/BfA/SiegeOfBoralus/Options/Sounds.lua
@@ -51,7 +51,7 @@ BigWigs:AddSounds("Siege of Boralus Trash", {
 	[257169] = "alarm",
 	[257170] = "long",
 	[257288] = "alert",
-	[257641] = "alert",
+	[257641] = "info",
 	[268260] = "alarm",
 	[272421] = "info",
 	[272711] = "alert",

--- a/BfA/SiegeOfBoralus/Options/Sounds.lua
+++ b/BfA/SiegeOfBoralus/Options/Sounds.lua
@@ -51,6 +51,7 @@ BigWigs:AddSounds("Siege of Boralus Trash", {
 	[257169] = "alarm",
 	[257170] = "long",
 	[257288] = "alert",
+	[257641] = "alert",
 	[268260] = "alarm",
 	[272421] = "info",
 	[272711] = "alert",

--- a/BfA/SiegeOfBoralus/Options/Sounds.lua
+++ b/BfA/SiegeOfBoralus/Options/Sounds.lua
@@ -5,7 +5,7 @@ BigWigs:AddSounds("Chopper Redhook", {
 	[257348] = "alert",
 	[257459] = "warning",
 	[257585] = "warning",
-	[273721] = "alert",
+	[273721] = {"alert","info"},
 	["adds"] = "long",
 })
 
@@ -14,7 +14,7 @@ BigWigs:AddSounds("Sergeant Bainbridge", {
 	[260924] = "alarm",
 	[260954] = "warning",
 	[261428] = "alert",
-	[277965] = "alert",
+	[277965] = {"alert","info"},
 	[279761] = "alert",
 	["adds"] = "long",
 })
@@ -39,6 +39,7 @@ BigWigs:AddSounds("Viq'Goth", {
 	[269266] = "alarm",
 	[269366] = "info",
 	[270185] = "alarm",
+	[270590] = "warning",
 	[275014] = "warning",
 	["demolishing"] = "alert",
 	["stages"] = "long",

--- a/BfA/SiegeOfBoralus/Options/Sounds.lua
+++ b/BfA/SiegeOfBoralus/Options/Sounds.lua
@@ -26,6 +26,7 @@ BigWigs:AddSounds("Dread Captain Lockwood", {
 	[268963] = "info",
 	[269029] = "alarm",
 	[272471] = "alert",
+	[273470] = "alert",
 })
 
 BigWigs:AddSounds("Hadal Darkfathom", {

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 17, CL.adds, L.adds_icon)
+	
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 17, CL.adds, L.adds_icon)
+	self:CDBar("adds", 33.1, CL.adds, L.adds_icon)
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -114,16 +114,23 @@ function mod:GoreCrash(args)
 	self:PlaySound(args.spellId, "alarm")
 end
 
-function mod:HeavyOrdnance(args)
-	local barText = CL.count:format(args.spellName, bombsRemaining)
-	bombsRemaining = bombsRemaining - 1
-	local timer = self:BarTimeLeft(barText)
-	if timer and bombsRemaining > 0 then
-		self:StopBar(barText)
-		self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
+do
+	local prev = 0
+	function mod:HeavyOrdnance(args)
+		local t = args.time
+		if t ~= prev then
+			prev = t
+			local barText = CL.count:format(args.spellName, bombsRemaining)
+			bombsRemaining = bombsRemaining - 1
+			local timer = self:BarTimeLeft(barText)
+			if timer and bombsRemaining > 0 then
+				self:StopBar(barText)
+				self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
+			end
+			self:Message2(273721, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
+			self:PlaySound(273721, "info")
+		end
 	end
-	self:Message2(273721, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
-	self:PlaySound(273721, "info")
 end
 
 function mod:HeavyOrdnanceApplied(args)

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -76,7 +76,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
-		self:Bar(273721, 42, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
+		self:Bar(273721, 43, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
 		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 		self:PlaySound("adds", "long")

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -75,11 +75,14 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		bombsRemaining = 3
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
-		self:Bar(257585, 60)
+		self:CDBar(257585, 60)
 		self:Bar(273721, 43, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
-	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
-		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
-		self:PlaySound("adds", "long")
+	elseif spellId == 274002 then -- Call Adds
+		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
+		if hp > 33 then -- Spams every second under 33% but doesn't actually span adds
+			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
+			self:PlaySound("adds", "long")
+		end
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -76,7 +76,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
-		self:Bar(273721, 45, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
+		self:Bar(273721, 42, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
 		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 		self:PlaySound("adds", "long")
@@ -118,7 +118,7 @@ function mod:HeavyOrdnance(args)
 	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
 	local timer = self:BarTimeLeft(barText)
-	if timer then
+	if timer and bombsRemaining > 0 then
 		self:StopBar(barText)
 		self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
@@ -130,7 +130,7 @@ function mod:HeavyOrdnanceApplied(args)
 	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
 	local timer = self:BarTimeLeft(barText)
-	if timer then
+	if timer and bombsRemaining > 0 then
 		self:StopBar(barText)
 		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
 	end

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -77,6 +77,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
+		self:Bar(273721, 45, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
 		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 		self:PlaySound("adds", "long")
@@ -115,13 +116,25 @@ function mod:GoreCrash(args)
 end
 
 function mod:HeavyOrdnance(args)
+	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
-	self:Message2(277965, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
-	self:PlaySound(277965, "info")
+	local timer = self:BarTimeLeft(barText)
+	if timer then
+		self:StopBar(barText)
+		self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
+	end
+	self:Message2(273721, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
+	self:PlaySound(273721, "info")
 end
 
 function mod:HeavyOrdnanceApplied(args)
+	local barText = CL.count:format(args.spellName, bombsRemaining)
 	bombsRemaining = bombsRemaining - 1
+	local timer = self:BarTimeLeft(barText)
+	if timer then
+		self:StopBar(barText)
+		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
+	end
 	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -23,7 +23,8 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
-	L.remaining = "%s (%d remaining)"
+	L.remaining = "%s, %d remaining"
+	L.used_remaining = "%s used, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -115,7 +116,7 @@ end
 
 function mod:HeavyOrdnance(args)
 	bombsRemaining = bombsRemaining - 1
-	self:Message2(277965, "orange", L.remaining:format(self:SpellName(277965), bombsRemaining))
+	self:Message2(277965, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
 	self:PlaySound(277965, "info")
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -66,12 +66,9 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
-	elseif spellId == 274002 then -- Call Adds
-		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-		if hp > 33 then -- Low CD under 33%
-			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
-			self:PlaySound("adds", "long")
-		end
+	elseif spellId == 274002 and not UnitExists("boss5") then -- Call Adds
+		self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
+		self:PlaySound("adds", "long")
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -108,7 +108,7 @@ function mod:GoreCrash(args)
 end
 
 function mod:HeavyOrdnance(args)
-	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName)) -- XXX Check if this does not mean it's also on adds
+	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "OnTheHookRemoved", 257459)
 	self:Log("SPELL_CAST_START", "MeatHook", 257348)
 	self:Log("SPELL_CAST_START", "GoreCrash", 257326)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280934) -- Damage to player, damage to add
+	self:Log("SPELL_DAMAGE", "HeavyOrdnanceDamage", 273720, 280934) -- Damage to player, damage to add
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 273721)
 end
 
@@ -79,7 +79,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:Bar(273721, 43, CL.count:format(self:SpellName(273721), bombsRemaining)) -- Heavy Ordnance
 	elseif spellId == 274002 then -- Call Adds
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
-		if hp > 33 then -- Spams every second under 33% but doesn't actually span adds
+		if hp > 33 then -- Spams every second under 33% but doesn't actually spawn adds
 			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 			self:PlaySound("adds", "long")
 		end
@@ -119,7 +119,7 @@ end
 
 do
 	local prev = 0
-	function mod:HeavyOrdnance(args)
+	function mod:HeavyOrdnanceDamage(args)
 		local t = args.time
 		if t ~= prev then
 			prev = t

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	
+
 end
 
 --------------------------------------------------------------------------------
@@ -67,12 +67,10 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 		self:PlaySound(257585, "warning")
 		self:CDBar(257585, 60) -- XXX Double check
 	elseif spellId == 274002 then -- Call Adds
-		self:StopBar(CL.adds)
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
 		if hp > 33 then -- Low CD under 33%
 			self:Message2("adds", "yellow", CL.incoming:format(CL.adds), false)
 			self:PlaySound("adds", "long")
-			self:CDBar("adds", 17, CL.adds, L.adds_icon) -- XXX Double check
 		end
 	end
 end

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "OnTheHookRemoved", 257459)
 	self:Log("SPELL_CAST_START", "MeatHook", 257348)
 	self:Log("SPELL_CAST_START", "GoreCrash", 257326)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720)
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720) -- XXX Damage to player, damage to add
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 273721)
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -23,7 +23,8 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
-	L.remaining = "%s, %d remaining"
+	L.remaining = "%s on %s, %d remaining"
+	L.remaining_boss = "%s on BOSS, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -130,7 +131,7 @@ do
 				self:StopBar(barText)
 				self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
 			end
-			self:Message2(273721, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
+			self:Message2(273721, "orange", L.remaining:format(args.spellName, args.destName, bombsRemaining))
 			self:PlaySound(273721, "info")
 		end
 	end
@@ -144,7 +145,7 @@ function mod:HeavyOrdnanceApplied(args)
 		self:StopBar(barText)
 		self:Bar(args.spellId, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
-	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
+	self:Message2(args.spellId, "green", L.remaining_boss:format(args.spellName, bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "OnTheHookRemoved", 257459)
 	self:Log("SPELL_CAST_START", "MeatHook", 257348)
 	self:Log("SPELL_CAST_START", "GoreCrash", 257326)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280934)
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280934) -- Damage to player, damage to add
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 273721)
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -50,7 +50,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "OnTheHookRemoved", 257459)
 	self:Log("SPELL_CAST_START", "MeatHook", 257348)
 	self:Log("SPELL_CAST_START", "GoreCrash", 257326)
-	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720) -- XXX Damage to player, damage to add
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720, 280934)
 	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 273721)
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -10,6 +10,12 @@ mod:RegisterEnableMob(128650) -- Chopper Redhook
 mod.engageId = 2098
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local bombsRemaining = 0
+
+--------------------------------------------------------------------------------
 -- Localization
 --
 
@@ -17,6 +23,7 @@ local L = mod:GetLocale()
 if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
+	L.remaining = "%s (%d remaining)"
 end
 
 --------------------------------------------------------------------------------
@@ -43,10 +50,12 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "OnTheHookRemoved", 257459)
 	self:Log("SPELL_CAST_START", "MeatHook", 257348)
 	self:Log("SPELL_CAST_START", "GoreCrash", 257326)
-	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnance", 273721)
+	self:Log("SPELL_DAMAGE", "HeavyOrdnance", 273720)
+	self:Log("SPELL_AURA_APPLIED", "HeavyOrdnanceApplied", 273721)
 end
 
 function mod:OnEngage()
+	bombsRemaining = 0
 	self:Bar(257585, 11) -- Cannon Barrage
 end
 
@@ -63,6 +72,7 @@ end
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 	if spellId == 257540 then -- Cannon Barrage
+		bombsRemaining = 3
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
 		self:Bar(257585, 60)
@@ -104,7 +114,14 @@ function mod:GoreCrash(args)
 end
 
 function mod:HeavyOrdnance(args)
-	self:Message2(args.spellId, "green", CL.onboss:format(args.spellName))
+	bombsRemaining = bombsRemaining - 1
+	self:Message2(277965, "orange", L.remaining:format(self:SpellName(277965), bombsRemaining))
+	self:PlaySound(277965, "info")
+end
+
+function mod:HeavyOrdnanceApplied(args)
+	bombsRemaining = bombsRemaining - 1
+	self:Message2(args.spellId, "green", L.remaining:format(CL.onboss:format(args.spellName), bombsRemaining))
 	self:PlaySound(args.spellId, "alert")
 	self:TargetBar(args.spellId, 6, args.destName)
 end

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-
+	self:Bar(257585, 10) -- Cannon Barrage
 end
 
 --------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, unit, _, spellId)
 	if spellId == 257540 then -- Cannon Barrage
 		self:Message2(257585, "orange")
 		self:PlaySound(257585, "warning")
-		self:CDBar(257585, 60) -- XXX Double check
+		self:Bar(257585, 60)
 	elseif spellId == 274002 then -- Call Adds
 		local hp = UnitHealth(unit) / UnitHealthMax(unit) * 100
 		if hp > 33 then -- Low CD under 33%

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -24,7 +24,6 @@ if L then
 	L.adds = 274002
 	L.adds_icon = "inv_misc_groupneedmore"
 	L.remaining = "%s, %d remaining"
-	L.used_remaining = "%s used, %d remaining"
 end
 
 --------------------------------------------------------------------------------
@@ -123,7 +122,7 @@ function mod:HeavyOrdnance(args)
 		self:StopBar(barText)
 		self:Bar(273721, timer, CL.count:format(args.spellName, bombsRemaining))
 	end
-	self:Message2(273721, "orange", L.used_remaining:format(args.spellName, bombsRemaining))
+	self:Message2(273721, "orange", L.remaining:format(CL.on:format(args.spellName, args.destName), bombsRemaining))
 	self:PlaySound(273721, "info")
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar("adds", 33.1, CL.adds, L.adds_icon)
+	self:CDBar("adds", 17, CL.adds, L.adds_icon)
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -98,7 +98,6 @@ do
 	end
 	function mod:MeatHook(args)
 		self:GetUnitTarget(printTarget, 0.1, args.sourceGUID)
-		-- self:CastBar(257348, 2.7)
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -47,7 +47,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:Bar(257585, 10) -- Cannon Barrage
+	self:Bar(257585, 11) -- Cannon Barrage
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -136,6 +136,7 @@ end
 function mod:SightedArtillery(args)
 	self:TargetMessage2(args.spellId, "yellow", args.destName)
 	self:PlaySound(args.spellId, "info")
+	self:TargetBar(args.spellId, 6, args.destName)
 end
 
 function mod:TerrifyingRoar(args)

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -92,7 +92,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "BolsteringShout", 275826)
 	self:Log("SPELL_CAST_SUCCESS", "BolsteringShoutSuccess", 275826)
 	-- Ashvane Spotter
-	self:Log("SPELL_AURA_APPLIED", "SightedArtillery", 272421)
+	self:Log("SPELL_CAST_START", "SightedArtillery", 272422)
+	self:Log("SPELL_AURA_APPLIED", "SightedArtilleryApplied", 272421)
 	-- Bilge Rat Demolisher
 	self:Log("SPELL_CAST_START", "TerrifyingRoar", 257169)
 	-- Bilge Rat Pillager
@@ -133,9 +134,26 @@ function mod:BolsteringShoutSuccess(args)
 	self:PlaySound(args.spellId, "alarm")
 end
 
-function mod:SightedArtillery(args)
-	self:TargetMessage2(args.spellId, "yellow", args.destName)
-	self:PlaySound(args.spellId, "info")
+do
+	local foundTarget = false
+	local function printTarget(self, name, guid)
+		foundTarget = true
+		self:TargetMessage2(272421, "yellow", name)
+		self:PlaySound(272421, "info")
+	end
+
+	function mod:SightedArtillery(args)
+		foundTarget = false
+		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
+	end
+
+	function mod:SightedArtilleryApplied(args)
+		self:TargetBar(args.spellId, 6, args.destName)
+		if not foundTarget then -- If the scan fails
+			self:TargetMessage2(args.spellId, "yellow", args.destName)
+			self:PlaySound(args.spellId, "info")
+		end
+	end
 end
 
 function mod:TerrifyingRoar(args)

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -187,7 +187,7 @@ do
 			if t-prev > 2 then
 				prev = t
 				self:PersonalMessage(257641) -- Molten Slug
-				self:PlaySound(257641, "alert") -- Molten Slug
+				self:PlaySound(257641, "info") -- Molten Slug
 			end
 		end
 	end

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -92,8 +92,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "BolsteringShout", 275826)
 	self:Log("SPELL_CAST_SUCCESS", "BolsteringShoutSuccess", 275826)
 	-- Ashvane Spotter
-	self:Log("SPELL_CAST_START", "SightedArtillery", 272422)
-	self:Log("SPELL_AURA_APPLIED", "SightedArtilleryApplied", 272421)
+	self:Log("SPELL_AURA_APPLIED", "SightedArtillery", 272421)
 	-- Bilge Rat Demolisher
 	self:Log("SPELL_CAST_START", "TerrifyingRoar", 257169)
 	-- Bilge Rat Pillager
@@ -134,26 +133,9 @@ function mod:BolsteringShoutSuccess(args)
 	self:PlaySound(args.spellId, "alarm")
 end
 
-do
-	local foundTarget = false
-	local function printTarget(self, name, guid)
-		foundTarget = true
-		self:TargetMessage2(272421, "yellow", name)
-		self:PlaySound(272421, "info")
-	end
-
-	function mod:SightedArtillery(args)
-		foundTarget = false
-		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
-	end
-
-	function mod:SightedArtilleryApplied(args)
-		self:TargetBar(args.spellId, 6, args.destName)
-		if not foundTarget then -- If the scan fails
-			self:TargetMessage2(args.spellId, "yellow", args.destName)
-			self:PlaySound(args.spellId, "info")
-		end
-	end
+function mod:SightedArtillery(args)
+	self:TargetMessage2(args.spellId, "yellow", args.destName)
+	self:PlaySound(args.spellId, "info")
 end
 
 function mod:TerrifyingRoar(args)

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -17,7 +17,8 @@ mod:RegisterEnableMob(
 	129369, -- Irontide Raider
 	141284, -- Kul Tiran Wavetender
 	141283, -- Kul Tiran Halberd
-	138019  -- Kul Tiran Vanguard
+	138019, -- Kul Tiran Vanguard
+	141285  -- Kul Tiran Marksman
 )
 
 --------------------------------------------------------------------------------
@@ -36,6 +37,7 @@ if L then
 	L.halberd = "Kul Tiran Halberd"
 	L.raider = "Irontide Raider"
 	L.vanguard = "Kul Tiran Vanguard"
+	L.marksman = "Kul Tiran Marksman"
 end
 
 --------------------------------------------------------------------------------
@@ -66,6 +68,8 @@ function mod:GetOptions()
 		256627, -- Slobber Knocker
 		-- Kul Tiran Vanguard
 		257288, -- Heavy Slash
+		-- Kul Tiran Marksman
+		257641, -- Molten Slug
 	}, {
 		[268260] = L.cannoneer,
 		[272874] = L.commander,
@@ -77,12 +81,13 @@ function mod:GetOptions()
 		[256957] = L.wavetender,
 		[256627] = L.halberd,
 		[257288] = L.vanguard,
+		[257641] = L.marksman,
 	}
 end
 
 function mod:OnBossEnable()
 	self:RegisterMessage("BigWigs_OnBossEngage", "Disable")
-	
+
 	-- Ashvane Commander
 	self:Log("SPELL_CAST_START", "BolsteringShout", 275826)
 	self:Log("SPELL_CAST_SUCCESS", "BolsteringShoutSuccess", 275826)
@@ -102,7 +107,9 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "WatertightShellApplied", 256957)
 	-- Kul Tiran Halberd
 	self:Log("SPELL_CAST_START", "SlobberKnocker", 256627)
-	
+	-- Kul Tiran Marksman
+	self:Log("SPELL_CAST_START", "MoltenSlug", 257641)
+
 	-- Ashvane Cannoneer's Broadside
 	-- Ashvane Commander's Trample
 	-- Bilge Rat Demolisher's Crushing Slam
@@ -169,6 +176,19 @@ end
 function mod:SlobberKnocker(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alert")
+end
+
+do
+	local function printTarget(self, name, guid)
+		if self:Me(guid) then
+			self:PersonalMessage(257641) -- Molten Slug
+			self:PlaySound(257641, "alert") -- Molten Slug
+		end
+	end
+
+	function mod:MoltenSlug(args)
+		self:GetUnitTarget(printTarget, 0.4, args.destGUID)
+	end
 end
 
 do

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -179,10 +179,15 @@ function mod:SlobberKnocker(args)
 end
 
 do
+	local prev = 0
 	local function printTarget(self, name, guid)
 		if self:Me(guid) then
-			self:PersonalMessage(257641) -- Molten Slug
-			self:PlaySound(257641, "alert") -- Molten Slug
+			local t = GetTime()
+			if t-prev > 2 then
+				prev = t
+				self:PersonalMessage(257641) -- Molten Slug
+				self:PlaySound(257641, "alert") -- Molten Slug
+			end
 		end
 	end
 

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -192,7 +192,7 @@ do
 	end
 
 	function mod:MoltenSlug(args)
-		self:GetUnitTarget(printTarget, 0.4, args.destGUID)
+		self:GetUnitTarget(printTarget, 0.4, args.sourceGUID)
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -45,7 +45,7 @@ function mod:GetOptions()
 end
 
 function mod:OnBossEnable()
-	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1")
+	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1", "boss2", "boss3", "boss4", "boss5")
 
 	self:Log("SPELL_AURA_APPLIED", "PutridWatersApplied", 275014)
 	self:Log("SPELL_AURA_REMOVED", "PutridWatersRemoved", 275014)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -159,6 +159,7 @@ end
 function mod:RepairStart(args)
 	self:Message2(args.spellId, "cyan", CL.casting:format(args.spellName))
 	self:PlaySound(args.spellId, "info")
+	self:CastBar(args.spellId, 3.5)
 end
 
 function mod:HullCracker(args)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -83,7 +83,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 			self:Message2("stages", "green", CL.stage:format(stage), false)
 			self:PlaySound("stages", "long")
 
-			self:CDBar("demolishing", stage == 2 and 39.5 or 55.5, L.demolishing, L.demolishing_icon) -- Summon Demolisher
+			self:CDBar("demolishing", 39.5, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 		end
 	elseif spellId == 270605 then -- Summon Demolisher
 		self:Message2("demolishing", "yellow", CL.spawned:format(self:SpellName(L.demolishing)), L.demolishing_icon)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -41,6 +41,7 @@ function mod:GetOptions()
 		"demolishing", -- Demolishing Terror
 		269266, -- Slam
 		269366, -- Repair
+		270590, -- Hull Cracker
 	}
 end
 
@@ -51,6 +52,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "PutridWatersRemoved", 275014)
 	self:Log("SPELL_CAST_START", "Slam", 269266)
 	self:Log("SPELL_CAST_START", "RepairStart", 269366)
+	self:Log("SPELL_CAST_START", "HullCracker", 270590)
 end
 
 function mod:OnEngage()
@@ -155,4 +157,9 @@ end
 function mod:RepairStart(args)
 	self:Message2(args.spellId, "cyan", CL.casting:format(args.spellName))
 	self:PlaySound(args.spellId, "info")
+end
+
+function mod:HullCracker(args)
+	self:Message2(args.spellId, "red")
+	self:PlaySound(args.spellId, "warning")
 end

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -53,6 +53,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "Slam", 269266)
 	self:Log("SPELL_CAST_START", "RepairStart", 269366)
 	self:Log("SPELL_CAST_START", "HullCracker", 270590)
+
+	self:Death("GrippingTerrorDeath", 137405) -- Gripping Terror
 end
 
 function mod:OnEngage()
@@ -162,4 +164,8 @@ end
 function mod:HullCracker(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
+end
+
+function mod:GrippingTerrorDeath(args)
+	self:StopBar(L.demolishing)
 end

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -66,7 +66,7 @@ function mod:OnEngage()
 	playersWithPutridWaters = {}
 	self:CDBar(275014, 5) -- Putrid Waters
 	self:CDBar(270185, 6) -- Call of the Deep
-	self:CDBar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
+	self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 end
 
 function mod:OnBossDisable()
@@ -105,7 +105,7 @@ do
 		"boss1", "boss2", "boss3", "boss4", "boss5"
 	}
 	local function findBossById(id)
-		for i = 2, 5 do
+		for i = 1, 5 do
 			local guid = UnitGUID(bossUnits[i])
 			if not guid then return end
 			if mod:MobId(guid) == id then

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -90,8 +90,6 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 			engagedGripping = false
 			self:Message2("stages", "green", CL.stage:format(stage), false)
 			self:PlaySound("stages", "long")
-
-			self:CDBar("demolishing", stage == 2 and 28 or 44, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 		end
 	elseif spellId == 270605 then -- Summon Demolisher
 		self:Message2("demolishing", "yellow", CL.spawned:format(self:SpellName(L.demolishing)), L.demolishing_icon)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -88,7 +88,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	elseif spellId == 270605 then -- Summon Demolisher
 		self:Message2("demolishing", "yellow", CL.spawned:format(self:SpellName(L.demolishing)), L.demolishing_icon)
 		self:PlaySound("demolishing", "alert")
-		self:CDBar("demolishing", 20, L.demolishing, L.demolishing_icon) -- XXX Need to Check
+		self:CDBar("demolishing", 20, L.demolishing, L.demolishing_icon)
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -94,9 +94,11 @@ end
 
 do
 	local isOnMe = false
-	local playerList = mod:NewTargetList()
+	local playerList, playerIcons = mod:NewTargetList(), {}
 	function mod:PutridWatersApplied(args)
-		playerList[#playerList+1] = args.destName
+		local playerListCount = #playerList+1
+		playerList[playerListCount] = args.destName
+		playerIcons[playerListCount] = markCount
 		playersWithPutridWaters[#playersWithPutridWaters + 1] = args.destName
 
 		if self:GetOption(putridWatersMarker) then
@@ -121,7 +123,7 @@ do
 		elseif not isOnMe then
 			self:OpenProximity(args.spellId, 10, playersWithPutridWaters)
 		end
-		self:TargetsMessage(args.spellId, "yellow", playerList, 2, nil, 0.6)
+		self:TargetsMessage(args.spellId, "yellow", playerList, 2, nil, nil, 0.6, playerIcons)
 	end
 
 	function mod:PutridWatersRemoved(args)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -99,25 +99,10 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	end
 end
 
-do
-	local bossUnits = {
-		"boss1", "boss2", "boss3", "boss4", "boss5"
-	}
-	local function findBossById(id)
-		for i = 1, 5 do
-			local guid = UnitGUID(bossUnits[i])
-			if not guid then return end
-			if mod:MobId(guid) == id then
-				return true
-			end
-		end
-	end
-
-	function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
-		if not engagedGripping and findBossById(137405) then -- Gripping Terror
-			engagedGripping = true
-			self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
-		end
+function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
+	if not engagedGripping and self:GetUnitIdByGUID(137405) then -- Check if Gripping Terror is up
+		engagedGripping = true
+		self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -47,8 +47,8 @@ function mod:GetOptions()
 end
 
 function mod:OnBossEnable()
+	-- The Gripping Terror can be any boss besides boss1, which is Viq'goth
 	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1", "boss2", "boss3", "boss4", "boss5")
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 
 	self:Log("SPELL_AURA_APPLIED", "PutridWatersApplied", 275014)
 	self:Log("SPELL_AURA_REMOVED", "PutridWatersRemoved", 275014)
@@ -60,6 +60,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 	stage = 1
 	markCount = 1
 	engagedGripping = true

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -83,7 +83,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 			self:Message2("stages", "green", CL.stage:format(stage), false)
 			self:PlaySound("stages", "long")
 
-			self:CDBar("demolishing", 39.5, L.demolishing, L.demolishing_icon) -- Summon Demolisher
+			self:CDBar("demolishing", stage == 2 and 28 or 44, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 		end
 	elseif spellId == 270605 then -- Summon Demolisher
 		self:Message2("demolishing", "yellow", CL.spawned:format(self:SpellName(L.demolishing)), L.demolishing_icon)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -100,7 +100,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 end
 
 function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
-	if not engagedGripping and self:GetUnitIdByGUID(137405) then -- Check if Gripping Terror is up
+	if not engagedGripping and self:GetBossIdByGUID(137405) then -- Check if Gripping Terror is up
 		engagedGripping = true
 		self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
 	end

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -121,7 +121,7 @@ do
 		elseif not isOnMe then
 			self:OpenProximity(args.spellId, 10, playersWithPutridWaters)
 		end
-		self:TargetsMessage(args.spellId, "yellow", playerList, 2)
+		self:TargetsMessage(args.spellId, "yellow", playerList, 2, nil, 0.6)
 	end
 
 	function mod:PutridWatersRemoved(args)


### PR DESCRIPTION
Bainbridge/Redhook:
- Add timer for Heavy Ordnance explosion
- Add remaining bomb count to Heavy Ordnance message
- Add Heavy Ordnance message for players and adds
- Remove add timer since they seem to spawn at health percentages

Lockwood:
- Improve timers for Clear the Deck, Withdraw, and Broadside
- Remove Crimson Swipe timer, and make messages tank only (they're just spam for non-tanks pretty much)
- Add Gut Shot target message

Darkfathom:
- Improve timers for Crashing Tide and Tidal Surge
- Add timer for Break Water damage (cast bar)

Viqgoth:
- Use TargetsMessage for Putrid Waters
- Add Hull Cracker message and sound
- Add Repair cast bar for the cannons
- Fix Demolishing Terror timer

Trash:
- Add Molten Slug personal messages when targeted