### PR TITLE
BfA/Underrot: Improve timers for all bosses

### DIFF
--- a/BfA/Underrot/Abomination.lua
+++ b/BfA/Underrot/Abomination.lua
@@ -71,7 +71,7 @@ do
 	end
 	function mod:CleansingLight(args)
 		self:GetBossTarget(printTarget, 0.4, args.sourceGUID)
-		self:CDBar(args.spellId, 26) -- 18.0, 26.7, 36.5 & 18.3, 28.0, 32.4
+		self:Bar(args.spellId, 26)
 	end
 	function mod:CleansingLightSuccess(args)
 		self:SecondaryIcon(args.spellId)

--- a/BfA/Underrot/Abomination.lua
+++ b/BfA/Underrot/Abomination.lua
@@ -58,9 +58,12 @@ function mod:VileExpulsion(args)
 end
 
 do
+	local prev = 0
 	local function printTarget(self, player, guid)
 		self:TargetMessage2(269310, "green", player)
 		self:PlaySound(269310, "long", "runin", player)
+		local elapsed = GetTime() - prev
+		self:TargetBar(269310, 5 - elapsed, player)
 		self:SecondaryIcon(269310, player)
 		if self:Me(guid) then
 			self:Say(269310)
@@ -72,6 +75,7 @@ do
 	function mod:CleansingLight(args)
 		self:GetBossTarget(printTarget, 0.4, args.sourceGUID)
 		self:Bar(args.spellId, 26)
+		prev = GetTime()
 	end
 	function mod:CleansingLightSuccess(args)
 		self:SecondaryIcon(args.spellId)

--- a/BfA/Underrot/Abomination.lua
+++ b/BfA/Underrot/Abomination.lua
@@ -58,11 +58,11 @@ function mod:VileExpulsion(args)
 end
 
 do
-	local prev = 0
+	local startTime = 0
 	local function printTarget(self, player, guid)
 		self:TargetMessage2(269310, "green", player)
 		self:PlaySound(269310, "long", "runin", player)
-		local elapsed = GetTime() - prev -- Subtract time spent scanning for the target
+		local elapsed = GetTime() - startTime -- Subtract time spent scanning for the target
 		self:TargetBar(269310, 5 - elapsed, player)
 		self:SecondaryIcon(269310, player)
 		if self:Me(guid) then
@@ -75,7 +75,7 @@ do
 	function mod:CleansingLight(args)
 		self:GetBossTarget(printTarget, 0.4, args.sourceGUID)
 		self:Bar(args.spellId, 26)
-		prev = GetTime()
+		startTime = GetTime()
 	end
 	function mod:CleansingLightSuccess(args)
 		self:SecondaryIcon(args.spellId)

--- a/BfA/Underrot/Abomination.lua
+++ b/BfA/Underrot/Abomination.lua
@@ -62,7 +62,7 @@ do
 	local function printTarget(self, player, guid)
 		self:TargetMessage2(269310, "green", player)
 		self:PlaySound(269310, "long", "runin", player)
-		local elapsed = GetTime() - prev
+		local elapsed = GetTime() - prev -- Subtract time spent scanning for the target
 		self:TargetBar(269310, 5 - elapsed, player)
 		self:SecondaryIcon(269310, player)
 		if self:Me(guid) then

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -45,7 +45,7 @@ end
 
 function mod:OnEngage()
 	firstCast = true
-	self:CBar(260292, 8, L.random_cast) -- Charge
+	self:CDBar(260292, 8, L.random_cast) -- Charge
 	if not self:Normal() then
 		self:Bar(260333, 45) -- Tantrum
 	end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -45,7 +45,7 @@ end
 
 function mod:OnEngage()
 	firstCast = true
-	self:CDBar(260292, 8, L.random_cast) -- Charge
+	self:CBar(260292, 8, L.random_cast) -- Charge
 	if not self:Normal() then
 		self:Bar(260333, 45) -- Tantrum
 	end
@@ -79,5 +79,6 @@ function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
 	self:CDBar(args.spellId, 45)
+	self:Bar(260292, 18, L.random_cast) -- Charge
 	firstCast = true
 end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -72,7 +72,7 @@ function mod:Indigestion(args)
 	self:PlaySound(args.spellId, "warning", "mobsoon")
 	if randomCast then
 		randomCast = false
-		if tantrumCount == 0 then -- He'll only do two charges if he hasn't tantrumed yet
+		if tantrumCount == 0 then -- He'll do two charges if he hasn't tantrumed yet
 			self:Bar(260292, 12, CL.count:format(self:SpellName(260292), 1)) -- Charge
 			self:Bar(260292, 32, CL.count:format(self:SpellName(260292), 2)) -- Charge
 		else

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -52,7 +52,7 @@ function mod:OnEngage()
 	tantrumCount = 0
 	self:CDBar("random_cast", 8, L.random_cast, "inv_misc_questionmark") -- Charge
 	if not self:Normal() then
-		self:Bar(260333, 45) -- Tantrum
+		self:CDBar(260333, 45) -- Tantrum estimate, updated after the first Chrage or Indigestion
 	end
 end
 
@@ -90,7 +90,7 @@ end
 function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
-	self:CDBar(args.spellId, 45)
+	self:CDBar(args.spellId, 45) -- Estimate, updated after the next Chrage or Indigestion
 	self:Bar("random_cast", 18, L.random_cast, "inv_misc_questionmark") -- Charge
 	randomCast = true
 	tantrumCount = tantrumCount + 1

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -70,8 +70,7 @@ function mod:Indigestion(args)
 	self:PlaySound(args.spellId, "warning", "mobsoon")
 	if firstCast then
 		firstCast = false
-		self:Bar(260292, 12, CL.count:format(self:SpellName(260292), 1)) -- Charge
-		self:Bar(260292, 32, CL.count:format(self:SpellName(260292), 2)) -- Charge
+		self:Bar(260292, 12) -- Charge
 	end
 end
 

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -50,7 +50,7 @@ end
 function mod:OnEngage()
 	randomCast = true
 	tantrumCount = 0
-	self:CDBar("random_cast", 8, L.random_cast) -- Charge
+	self:CDBar("random_cast", 8, L.random_cast, "inv_misc_questionmark") -- Charge
 	if not self:Normal() then
 		self:Bar(260333, 45) -- Tantrum
 	end
@@ -91,7 +91,7 @@ function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
 	self:CDBar(args.spellId, 45)
-	self:Bar("random_cast", 18, L.random_cast) -- Charge
+	self:Bar("random_cast", 18, L.random_cast, "inv_misc_questionmark") -- Charge
 	randomCast = true
 	tantrumCount = tantrumCount + 1
 end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -64,6 +64,7 @@ function mod:Charge(args)
 		randomCast = false
 		self:Bar(args.spellId, 23)
 		self:Bar(260793, 11) -- Indigestion
+		self:Bar(260333, tantrumCount == 0 and 37.6 or 34) -- Tantrum
 	end
 end
 
@@ -75,8 +76,10 @@ function mod:Indigestion(args)
 		if tantrumCount == 0 then -- He'll do two charges if he hasn't tantrumed yet
 			self:Bar(260292, 12, CL.count:format(self:SpellName(260292), 1)) -- Charge
 			self:Bar(260292, 32, CL.count:format(self:SpellName(260292), 2)) -- Charge
+			self:Bar(260333, 43.6) -- Tantrum
 		else
 			self:Bar(260292, 12) -- Charge
+			self:Bar(260333, 26.7) -- Tantrum
 		end
 	end
 end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Infested Crawg", 1841, 2131)
 if not mod then return end
 mod:RegisterEnableMob(131817)
 mod.engageId = 2118
+mod.respawnTime = 25
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -9,6 +9,21 @@ mod:RegisterEnableMob(131817)
 mod.engageId = 2118
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local firstCast = true
+
+--------------------------------------------------------------------------------
+-- Localization
+--
+
+local L = mod:GetLocale()
+if L then
+	L.random_cast = "Random Cast"
+end
+
+--------------------------------------------------------------------------------
 -- Initialization
 --
 
@@ -29,10 +44,10 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:CDBar(260793, 8) -- Indigestion
-	self:CDBar(260292, 21) -- Charge
+	firstCast = true
+	self:CDBar(260292, 8, L.random_cast) -- Charge
 	if not self:Normal() then
-		self:CDBar(260333, 45) -- Tantrum
+		self:Bar(260333, 45) -- Tantrum
 	end
 end
 
@@ -43,17 +58,26 @@ end
 function mod:Charge(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "alert", "watchstep")
-	self:CDBar(args.spellId, 20)
+	if firstCast then
+		firstCast = false
+		self:Bar(args.spellId, 23)
+		self:Bar(260793, 11) -- Indigestion
+	end
 end
 
 function mod:Indigestion(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning", "mobsoon")
-	self:CDBar(args.spellId, 42)
+	if firstCast then
+		firstCast = false
+		self:Bar(260292, 12, CL.count:format(self:SpellName(260292), 1)) -- Charge
+		self:Bar(260292, 32, CL.count:format(self:SpellName(260292), 2)) -- Charge
+	end
 end
 
 function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
 	self:CDBar(args.spellId, 45)
+	firstCast = true
 end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -53,7 +53,7 @@ function mod:OnEngage()
 	tantrumCount = 0
 	self:CDBar("random_cast", 8, L.random_cast, "inv_misc_questionmark") -- Charge
 	if not self:Normal() then
-		self:CDBar(260333, 45) -- Tantrum estimate, updated after the first Chrage or Indigestion
+		self:CDBar(260333, 45) -- Tantrum estimate, updated after the first Charge or Indigestion
 	end
 end
 
@@ -91,7 +91,7 @@ end
 function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
-	self:CDBar(args.spellId, 45) -- Estimate, updated after the next Chrage or Indigestion
+	self:CDBar(args.spellId, 45) -- Estimate, updated after the next Charge or Indigestion
 	self:Bar("random_cast", 18, L.random_cast, "inv_misc_questionmark") -- Charge
 	randomCast = true
 	tantrumCount = tantrumCount + 1

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -21,7 +21,7 @@ local tantrumCount = 0
 
 local L = mod:GetLocale()
 if L then
-	L.random_cast = "Random Cast"
+	L.random_cast = "Charge or Indigestion"
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -22,6 +22,8 @@ local tantrumCount = 0
 local L = mod:GetLocale()
 if L then
 	L.random_cast = "Charge or Indigestion"
+	L.random_cast_desc = "The first cast after each Tantrum is random."
+	L.random_cast_icon = "inv_misc_questionmark"
 end
 
 --------------------------------------------------------------------------------
@@ -30,6 +32,7 @@ end
 
 function mod:GetOptions()
 	return {
+		"random_cast",
 		260292, -- Charge
 		260793, -- Indigestion
 		260333, -- Tantrum
@@ -47,7 +50,7 @@ end
 function mod:OnEngage()
 	randomCast = true
 	tantrumCount = 0
-	self:CDBar(260292, 8, L.random_cast) -- Charge
+	self:CDBar("random_cast", 8, L.random_cast) -- Charge
 	if not self:Normal() then
 		self:Bar(260333, 45) -- Tantrum
 	end
@@ -88,7 +91,7 @@ function mod:Tantrum(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "long", "mobsoon")
 	self:CDBar(args.spellId, 45)
-	self:Bar(260292, 18, L.random_cast) -- Charge
+	self:Bar("random_cast", 18, L.random_cast) -- Charge
 	randomCast = true
 	tantrumCount = tantrumCount + 1
 end

--- a/BfA/Underrot/Crawg.lua
+++ b/BfA/Underrot/Crawg.lua
@@ -12,7 +12,8 @@ mod.engageId = 2118
 -- Locals
 --
 
-local firstCast = true
+local randomCast = true
+local tantrumCount = 0
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -44,7 +45,8 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	firstCast = true
+	randomCast = true
+	tantrumCount = 0
 	self:CDBar(260292, 8, L.random_cast) -- Charge
 	if not self:Normal() then
 		self:Bar(260333, 45) -- Tantrum
@@ -58,8 +60,8 @@ end
 function mod:Charge(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "alert", "watchstep")
-	if firstCast then
-		firstCast = false
+	if randomCast then
+		randomCast = false
 		self:Bar(args.spellId, 23)
 		self:Bar(260793, 11) -- Indigestion
 	end
@@ -68,9 +70,14 @@ end
 function mod:Indigestion(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning", "mobsoon")
-	if firstCast then
-		firstCast = false
-		self:Bar(260292, 12) -- Charge
+	if randomCast then
+		randomCast = false
+		if tantrumCount == 0 then -- He'll only do two charges if he hasn't tantrumed yet
+			self:Bar(260292, 12, CL.count:format(self:SpellName(260292), 1)) -- Charge
+			self:Bar(260292, 32, CL.count:format(self:SpellName(260292), 2)) -- Charge
+		else
+			self:Bar(260292, 12) -- Charge
+		end
 	end
 end
 
@@ -79,5 +86,6 @@ function mod:Tantrum(args)
 	self:PlaySound(args.spellId, "long", "mobsoon")
 	self:CDBar(args.spellId, 45)
 	self:Bar(260292, 18, L.random_cast) -- Charge
-	firstCast = true
+	randomCast = true
+	tantrumCount = tantrumCount + 1
 end

--- a/BfA/Underrot/Leaxa.lua
+++ b/BfA/Underrot/Leaxa.lua
@@ -74,7 +74,7 @@ end
 
 function mod:BloodMirror(args)
 	self:Message2(args.spellId, "red")
-	self:PlaySound(args.spellId, "long", "intermission")
+	self:PlaySound(args.spellId, "long")
 	self:Bar(args.spellId, 47.4)
 end
 

--- a/BfA/Underrot/Leaxa.lua
+++ b/BfA/Underrot/Leaxa.lua
@@ -25,7 +25,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "BloodBolt", 260879)
 	self:Log("SPELL_CAST_START", "CreepingRot", 260894)
 	self:Log("SPELL_CAST_START", "BloodMirror", 264603)
-	self:Death("EffigyDeath", 134701)
 
 	-- Heroic+
 	self:Log("SPELL_CAST_START", "SanguineFeast", 264757)
@@ -77,11 +76,6 @@ function mod:BloodMirror(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "long", "intermission")
 	self:Bar(args.spellId, 47.4)
-end
-
-function mod:EffigyDeath(args)
-	self:Message2(264603, "green", CL.over:format(self:SpellName(264603)))
-	self:PlaySound(264603, "long", "stage")
 end
 
 function mod:SanguineFeast(args)

--- a/BfA/Underrot/Leaxa.lua
+++ b/BfA/Underrot/Leaxa.lua
@@ -32,7 +32,7 @@ end
 
 function mod:OnEngage()
 	self:Bar(260894, 12) -- Creeping Rot
-	self:Bar(264603, 19) -- Blood Mirror
+	self:CDBar(264603, 15.5) -- Blood Mirror
 	if not self:Normal() then
 		self:Bar(264757, 9) -- Sanguine Feast
 	end

--- a/BfA/Underrot/Leaxa.lua
+++ b/BfA/Underrot/Leaxa.lua
@@ -33,7 +33,7 @@ end
 
 function mod:OnEngage()
 	self:Bar(260894, 12) -- Creeping Rot
-	self:Bar(264603, 15.5) -- Blood Mirror
+	self:Bar(264603, 19) -- Blood Mirror
 	if not self:Normal() then
 		self:Bar(264757, 9) -- Sanguine Feast
 	end
@@ -76,6 +76,7 @@ end
 function mod:BloodMirror(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "long", "intermission")
+	self:Bar(args.spellId, 47.4)
 end
 
 function mod:EffigyDeath(args)

--- a/BfA/Underrot/Leaxa.lua
+++ b/BfA/Underrot/Leaxa.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Elder Leaxa", 1841, 2157)
 if not mod then return end
 mod:RegisterEnableMob(131318)
 mod.engageId = 2111
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/BfA/Underrot/Locales/deDE.lua
+++ b/BfA/Underrot/Locales/deDE.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "deDE")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/deDE.lua
+++ b/BfA/Underrot/Locales/deDE.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Blutverschworener Schänder"
 	L.corruptor = "Gesichtsloser Verderber"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "deDE")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/deDE.lua
+++ b/BfA/Underrot/Locales/deDE.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "deDE")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/esES.lua
+++ b/BfA/Underrot/Locales/esES.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "esES") or BigWigs:NewBossLocale("Infested Crawg", "esMX")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/esES.lua
+++ b/BfA/Underrot/Locales/esES.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "esES") or BigWigs:NewBossLocale("Infested Crawg", "esMX")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/esES.lua
+++ b/BfA/Underrot/Locales/esES.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Profanador Jurasangre"
 	L.corruptor = "Corruptor ignoto"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "esES") or BigWigs:NewBossLocale("Infested Crawg", "esMX")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/frFR.lua
+++ b/BfA/Underrot/Locales/frFR.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "frFR")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/frFR.lua
+++ b/BfA/Underrot/Locales/frFR.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "frFR")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/frFR.lua
+++ b/BfA/Underrot/Locales/frFR.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Profanateur lige-sang"
 	L.corruptor = "Corrupteur sans-visage"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "frFR")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/itIT.lua
+++ b/BfA/Underrot/Locales/itIT.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Profanatore Giurasangue"
 	L.corruptor = "Corruttore Senzavolto"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "itIT")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/itIT.lua
+++ b/BfA/Underrot/Locales/itIT.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "itIT")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/itIT.lua
+++ b/BfA/Underrot/Locales/itIT.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "itIT")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/koKR.lua
+++ b/BfA/Underrot/Locales/koKR.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "koKR")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+    -- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/koKR.lua
+++ b/BfA/Underrot/Locales/koKR.lua
@@ -12,3 +12,8 @@ if L then
 	-- L.defiler = "Bloodsworn Defiler"
 	-- L.corruptor = "Faceless Corruptor"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "koKR")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/koKR.lua
+++ b/BfA/Underrot/Locales/koKR.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "koKR")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/ptBR.lua
+++ b/BfA/Underrot/Locales/ptBR.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "ptBR")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/ptBR.lua
+++ b/BfA/Underrot/Locales/ptBR.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "ptBR")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/ptBR.lua
+++ b/BfA/Underrot/Locales/ptBR.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Corruptor Jurassangue"
 	L.corruptor = "Corruptor Sem-rosto"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "ptBR")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/ruRU.lua
+++ b/BfA/Underrot/Locales/ruRU.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "Кровавый осквернитель"
 	L.corruptor = "Безликий осквернитель"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "ruRU")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/ruRU.lua
+++ b/BfA/Underrot/Locales/ruRU.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "ruRU")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/ruRU.lua
+++ b/BfA/Underrot/Locales/ruRU.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "ruRU")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/zhCN.lua
+++ b/BfA/Underrot/Locales/zhCN.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "zhCN")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/zhCN.lua
+++ b/BfA/Underrot/Locales/zhCN.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "血誓污染者"
 	L.corruptor = "无面腐蚀者"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "zhCN")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Locales/zhCN.lua
+++ b/BfA/Underrot/Locales/zhCN.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "zhCN")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/zhTW.lua
+++ b/BfA/Underrot/Locales/zhTW.lua
@@ -15,5 +15,5 @@ end
 
 L = BigWigs:NewBossLocale("Infested Crawg", "zhTW")
 if L then
-	-- L.random_cast = "Random Cast"
+	-- L.random_cast = "Charge or Indigestion"
 end

--- a/BfA/Underrot/Locales/zhTW.lua
+++ b/BfA/Underrot/Locales/zhTW.lua
@@ -16,4 +16,5 @@ end
 L = BigWigs:NewBossLocale("Infested Crawg", "zhTW")
 if L then
 	-- L.random_cast = "Charge or Indigestion"
+	-- L.random_cast_desc = "The first cast after each Tantrum is random."
 end

--- a/BfA/Underrot/Locales/zhTW.lua
+++ b/BfA/Underrot/Locales/zhTW.lua
@@ -12,3 +12,8 @@ if L then
 	L.defiler = "血誓污染者"
 	L.corruptor = "無面墮落者"
 end
+
+L = BigWigs:NewBossLocale("Infested Crawg", "zhTW")
+if L then
+	-- L.random_cast = "Random Cast"
+end

--- a/BfA/Underrot/Options/Colors.lua
+++ b/BfA/Underrot/Options/Colors.lua
@@ -2,7 +2,7 @@
 BigWigs:AddColors("Elder Leaxa", {
 	[260879] = "orange",
 	[260894] = "yellow",
-	[264603] = {"green","red"},
+	[264603] = "red",
 	[264757] = "yellow",
 })
 

--- a/BfA/Underrot/Zancha.lua
+++ b/BfA/Underrot/Zancha.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Sporecaller Zancha", 1841, 2130)
 if not mod then return end
 mod:RegisterEnableMob(131383)
 mod.engageId = 2112
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/BfA/Underrot/Zancha.lua
+++ b/BfA/Underrot/Zancha.lua
@@ -37,6 +37,7 @@ function mod:OnEngage()
 	self:Bar(272457, 10) -- Shockwave
 	self:Bar(259718, 16) -- Upheaval
 	self:Bar(259732, 45) -- Festering Harvest
+	self:Bar(273285, 46) -- Volatile Pods
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/Underrot/Zancha.lua
+++ b/BfA/Underrot/Zancha.lua
@@ -18,7 +18,7 @@ function mod:GetOptions()
 		259830, -- Boundless Rot
 		272457, -- Shockwave
 		{259718, "SAY", "SAY_COUNTDOWN", "FLASH"}, -- Upheaval
-		273285,
+		273285, -- Volatile Pods
 	}
 end
 
@@ -91,8 +91,8 @@ do
 		if t-prev > 2 then
 			prev = t
 			self:Message2(args.spellId, "yellow")
-			self:PlaySound(args.spellId, "long", "interrupt")
-			self:CDBar(args.spellId, 30)
+			self:PlaySound(args.spellId, "long")
+			self:CDBar(args.spellId, 25)
 		end
 	end
 end

--- a/BfA/Underrot/Zancha.lua
+++ b/BfA/Underrot/Zancha.lua
@@ -36,7 +36,7 @@ end
 function mod:OnEngage()
 	self:Bar(272457, 10) -- Shockwave
 	self:Bar(259718, 16) -- Upheaval
-	self:Bar(259732, 35) -- Festering Harvest
+	self:Bar(259732, 45) -- Festering Harvest
 end
 
 --------------------------------------------------------------------------------
@@ -47,6 +47,7 @@ function mod:FesteringHarvest(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
 	self:Bar(args.spellId, 51)
+	self:Bar(259718, 15) -- Upheaval
 end
 
 function mod:BoundlessRot(args)


### PR DESCRIPTION
closes #422 

Leaxa:
- Remove death message for adds. It was left over from before the hotfix that changed the number of adds spawned to always be 1.

Crawg:
- Rename the first bar after each tantrum to "Charge or Indigestion" since it's random
- Improve accuracy of all timers

Zancha:
- Improve timers for Volatile Pods and Festering Harvest

Abomination:
- Add target bar for Cleansing Light