### PR TITLE
BfA/Underrot/Trash: Remove Wave of Decay cast message

### DIFF
--- a/BfA/Underrot/Options/Colors.lua
+++ b/BfA/Underrot/Options/Colors.lua
@@ -37,7 +37,7 @@ BigWigs:AddColors("Underrot Trash", {
 	[265523] = "yellow",
 	[265540] = "yellow",
 	[265568] = {"blue","cyan"},
-	[265668] = {"blue","yellow"},
+	[265668] = "blue",
 	[266106] = "red",
 	[266107] = "blue",
 	[266209] = "cyan",

--- a/BfA/Underrot/Options/Sounds.lua
+++ b/BfA/Underrot/Options/Sounds.lua
@@ -37,7 +37,7 @@ BigWigs:AddSounds("Underrot Trash", {
 	[265523] = "alarm",
 	[265540] = "alarm",
 	[265568] = {"alarm","alert"},
-	[265668] = {"alarm","alert"},
+	[265668] = "alarm",
 	[266106] = "warning",
 	[266107] = "alarm",
 	[266209] = "info",

--- a/BfA/Underrot/Trash.lua
+++ b/BfA/Underrot/Trash.lua
@@ -108,8 +108,6 @@ function mod:OnBossEnable()
 	-- Feral Bloodswarmer
 	self:Log("SPELL_AURA_APPLIED", "ThirstForBloodApplied", 266107)
 	self:Log("SPELL_CAST_START", "SonicScreech", 266106)
-	-- Living Rot
-	self:Log("SPELL_CAST_START", "WaveOfDecay", 265668)
 	-- Fallen Deathspeaker
 	self:Log("SPELL_CAST_START", "RaiseDead", 272183)
 	self:Log("SPELL_CAST_START", "WickedFrenzy", 266209)
@@ -227,12 +225,6 @@ end
 function mod:SonicScreech(args)
 	self:Message2(args.spellId, "red", CL.casting:format(args.spellName))
 	self:PlaySound(args.spellId, "warning")
-end
-
--- Living Rot
-function mod:WaveOfDecay(args)
-	self:Message2(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
 end
 
 -- Fallen Deathspeaker


### PR DESCRIPTION
It's not worth interrupting (there are more important things) and it's really spammy.