### PR TITLE
BfA/Freehold: Add Captain Jolly and add messages when brews are applied to bosses

### DIFF
--- a/BfA/Freehold/Booty.lua
+++ b/BfA/Freehold/Booty.lua
@@ -13,6 +13,7 @@ mod:RegisterEnableMob(
 	126969 -- Trothak
 )
 mod.engageId = 2095
+mod.respawnTime = 25
 
 --------------------------------------------------------------------------------
 -- Localization

--- a/BfA/Freehold/Captains.lua
+++ b/BfA/Freehold/Captains.lua
@@ -67,17 +67,17 @@ end
 
 do
 	local function startTimers()
-		local elapsed = 0.1
+		-- 0.1 sec is subtracted from the timers
 		if UnitCanAttack("player", mod:GetBossId(126847)) then -- Captain Raoul
-			mod:Bar(256589, 6.9 - elapsed) -- Barrel Smash
-			mod:Bar(258338, 19 - elapsed) -- Blackout Barrel
+			mod:Bar(256589, 6.8) -- Barrel Smash, 6.9 sec
+			mod:Bar(258338, 18.9) -- Blackout Barrel, 19 sec
 		end
 		if UnitCanAttack("player", mod:GetBossId(126848)) then -- Captain Eudora
-			mod:Bar(258381, 8.5 - elapsed) -- Grape Shot
+			mod:Bar(258381, 8.4) -- Grape Shot, 8.5 sec
 		end
 		if UnitCanAttack("player", mod:GetBossId(126845)) then -- Captain Jolly
-			mod:Bar(267533, 13 - elapsed) -- Whirlpool of Blades
-			mod:Bar(267522, 5.7 - elapsed) -- Cutting Surge
+			mod:Bar(267533, 12.9) -- Whirlpool of Blades, 13 sec
+			mod:Bar(267522, 5.6) -- Cutting Surge, 5.7 sec
 		end
 	end
 

--- a/BfA/Freehold/Captains.lua
+++ b/BfA/Freehold/Captains.lua
@@ -1,9 +1,5 @@
 
 --------------------------------------------------------------------------------
--- TODO:
--- -- Lucky Sevens positive buff message?
-
---------------------------------------------------------------------------------
 -- Module Declaration
 --
 
@@ -11,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Council o' Captains", 1754, 2093)
 if not mod then return end
 mod:RegisterEnableMob(126847, 126848, 126845) -- Captain Raoul, Captain Eudora, Captain Jolly
 mod.engageId = 2094
+mod.respawnTime = 17.5
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -29,10 +26,15 @@ end
 
 function mod:GetOptions()
 	return {
+		-- Captain Raoul
 		258338, -- Blackout Barrel
 		256589, -- Barrel Smash
+		-- Captain Eudora
 		258381, -- Grape Shot
 		256979, -- Powder Shot
+		-- Captain Jolly
+		267533, -- Whirlpool of Blades
+		267522, -- Cutting Surge
 		--[[ Tending Bar ]]--
 		265088, -- Confidence-Boosting Brew (Crit)
 		264608, -- Invigorating Brew (Haste)
@@ -40,6 +42,7 @@ function mod:GetOptions()
 	},{
 		[258338] = -17023, -- Captain Raoul
 		[258381] = -17024, -- Captain Eudora
+		[267533] = -17025, -- Captain Jolly
 		[265088] = -18476, -- Rummy Mancomb
 	}
 end
@@ -49,20 +52,38 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "BarrelSmash", 256589)
 	self:Log("SPELL_CAST_SUCCESS", "GrapeShot", 258381)
 	self:Log("SPELL_CAST_START", "PowderShot", 256979)
+	self:Log("SPELL_CAST_START", "WhirlpoolofBlades", 267533)
+	self:Log("SPELL_CAST_START", "CuttingSurge", 267522)
 
 	self:Log("SPELL_CAST_SUCCESS", "CritBrew", 265088)
+	self:Log("SPELL_AURA_APPLIED", "CritBrewApplied", 265085)
 	self:Log("SPELL_CAST_SUCCESS", "HasteBrew", 264608)
+	self:Log("SPELL_AURA_APPLIED", "HasteBrewApplied", 265056)
 	self:Log("SPELL_CAST_SUCCESS", "CausticBrew", 265168)
-	self:Log("SPELL_AURA_APPLIED", "CausticBrewDamage", 278467)
-	self:Log("SPELL_PERIODIC_DAMAGE", "CausticBrewDamage", 278467)
+	self:Log("SPELL_AURA_APPLIED", "CausticBrewApplied", 278467)
 
 	self:Death("Deaths", 126847, 126848, 126845)
 end
 
-function mod:OnEngage()
-	self:Bar(256589, 6) -- Barrel Smash
-	self:Bar(258381, 8.5) -- Grape Shot
-	self:Bar(258338, 19.4) -- Blackout Barrel
+do
+	local function startTimers()
+		local elapsed = 0.1
+		if UnitCanAttack("player", mod:GetBossId(126847)) then -- Captain Raoul
+			mod:Bar(256589, 6.9 - elapsed) -- Barrel Smash
+			mod:Bar(258338, 19 - elapsed) -- Blackout Barrel
+		end
+		if UnitCanAttack("player", mod:GetBossId(126848)) then -- Captain Eudora
+			mod:Bar(258381, 8.5 - elapsed) -- Grape Shot
+		end
+		if UnitCanAttack("player", mod:GetBossId(126845)) then -- Captain Jolly
+			mod:Bar(267533, 13 - elapsed) -- Whirlpool of Blades
+			mod:Bar(267522, 5.7 - elapsed) -- Cutting Surge
+		end
+	end
+
+	function mod:OnEngage()
+		self:SimpleTimer(startTimers, 0.1)
+	end
 end
 
 function mod:VerifyEnable(unit)
@@ -79,6 +100,9 @@ function mod:Deaths(args)
 		self:StopBar(256589) -- Barrel Smash
 	elseif args.mobId == 126848 then -- Captain Eudora
 		self:StopBar(258381) -- Grape Shot
+	elseif args.mobId == 126845 then -- Captain Jolly
+		self:StopBar(267533) -- Whirlpool of Blades
+		self:StopBar(267522) -- Cutting Surge
 	end
 end
 
@@ -114,14 +138,62 @@ do
 	end
 end
 
+function mod:WhirlpoolofBlades(args)
+	self:Message2(args.spellId, "orange")
+	self:PlaySound(args.spellId, "alert")
+	self:CDBar(args.spellId, 20)
+end
+
+function mod:CuttingSurge(args)
+	self:Message2(args.spellId, "orange")
+	self:PlaySound(args.spellId, "alert")
+	self:CDBar(args.spellId, 23)
+end
+
 function mod:CritBrew(args)
 	self:Message2(args.spellId, "green", L.crit_brew)
 	self:PlaySound(args.spellId, "info")
 end
 
+do
+	local prev = 0
+	function mod:CritBrewApplied(args)
+		local t = args.time
+		if self:Me(args.destGUID) then
+			self:PersonalMessage(265088, nil, L.crit_brew)
+			self:PlaySound(265088, "info")
+		elseif self:Tank() and t-prev > 2 then -- Announce boss crit buff to tanks
+			local bossId = self:GetBossId(args.destGUID)
+			if bossId and UnitCanAttack("player", bossId) then
+				prev = t
+				self:Message2(265088, "purple", CL.onboss:format(L.crit_brew))
+				self:PlaySound(265088, "alarm")
+			end
+		end
+	end
+end
+
 function mod:HasteBrew(args)
 	self:Message2(args.spellId, "green", L.haste_brew)
 	self:PlaySound(args.spellId, "info")
+end
+
+do
+	local prev = 0
+	function mod:HasteBrewApplied(args)
+		local t = args.time
+		if self:Me(args.destGUID) then
+			self:PersonalMessage(264608, nil, L.haste_brew)
+			self:PlaySound(264608, "info")
+		elseif self:Tank() and t-prev > 2 then -- Announce boss haste buff to tanks
+			local bossId = self:GetBossId(args.destGUID)
+			if bossId and UnitCanAttack("player", bossId) then
+				prev = t
+				self:Message2(264608, "purple", CL.onboss:format(L.haste_brew))
+				self:PlaySound(264608, "alarm")
+			end
+		end
+	end
 end
 
 function mod:CausticBrew(args)
@@ -131,13 +203,17 @@ end
 
 do
 	local prev = 0
-	function mod:CausticBrewDamage(args)
+	function mod:CausticBrewApplied(args)
+		local t = args.time
 		if self:Me(args.destGUID) then
-			local t = args.time
-			if t-prev > 2 then
+			self:PersonalMessage(265168, "underyou", L.bad_brew)
+			self:PlaySound(265168, "alarm")
+		elseif self:Tank() and t-prev > 2 then -- Announce DoT on boss to tanks
+			local bossId = self:GetBossId(args.destGUID)
+			if bossId and UnitCanAttack("player", bossId) then
 				prev = t
-				self:PersonalMessage(265168, "underyou", L.bad_brew)
-				self:PlaySound(265168, "alarm")
+				self:Message2(265168, "green", CL.onboss:format(L.bad_brew))
+				self:PlaySound(265168, "info")
 			end
 		end
 	end

--- a/BfA/Freehold/Kragg.lua
+++ b/BfA/Freehold/Kragg.lua
@@ -53,7 +53,8 @@ end
 --
 
 do
-	local prev = 0
+	local prevBombardment = 0
+	local prevDamage = 0
 	function mod:VileBombardment(args)
 		self:Message2(args.spellId, "yellow")
 		self:PlaySound(args.spellId, "info")
@@ -61,8 +62,19 @@ do
 			self:Bar(args.spellId, 6)
 		else
 			local t = args.time
-			self:Bar(args.spellId, t-prev > 8 and 6 or 10.8)
-			prev = t
+			self:Bar(args.spellId, t-prevBombardment > 8 and 6 or 10.8)
+			prevBombardment = t
+		end
+	end
+
+	function mod:VileCoatingDamage(args)
+		if self:Me(args.destGUID) then
+			local t = args.time
+			if t-prevDamage > 1.5 and t-prevBombardment > 2 then
+				prevDamage = t
+				self:PersonalMessage(args.spellId, "underyou")
+				self:PlaySound(args.spellId, "alarm", "gtfo")
+			end
 		end
 	end
 end
@@ -76,7 +88,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		self:CDBar(256106, 7) -- Azerite Powder Shot
 		self:Bar(256005, 6) -- Vile Bombardment
 		if not self:Normal() then
-			-- XXX initial Dive Bomb timer
+			self:Bar(272046, 17) -- Dive Bomb
 		end
 	end
 end
@@ -90,7 +102,7 @@ end
 function mod:DiveBomb(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm")
-	self:CDBar(args.spellId, 15.5) -- ranges from 12-18
+	self:Bar(args.spellId, 17)
 end
 
 function mod:AzeritePowderShot(args)
@@ -102,18 +114,4 @@ end
 function mod:RevitalizingBrew(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning", "interrupt")
-end
-
-do
-	local prev = 0
-	function mod:VileCoatingDamage(args)
-		if self:Me(args.destGUID) then
-			local t = args.time
-			if t-prev > 1.5 then
-				prev = t
-				self:PersonalMessage(args.spellId, "underyou")
-				self:PlaySound(args.spellId, "alarm", "gtfo")
-			end
-		end
-	end
 end

--- a/BfA/Freehold/Kragg.lua
+++ b/BfA/Freehold/Kragg.lua
@@ -70,6 +70,7 @@ do
 	function mod:VileCoatingDamage(args)
 		if self:Me(args.destGUID) then
 			local t = args.time
+			-- Don't show message for the first tick after vile bombardment lands
 			if t-prevDamage > 1.5 and t-prevBombardment > 2 then
 				prevDamage = t
 				self:PersonalMessage(args.spellId, "underyou")

--- a/BfA/Freehold/Options/Colors.lua
+++ b/BfA/Freehold/Options/Colors.lua
@@ -14,9 +14,11 @@ BigWigs:AddColors("Council o' Captains", {
 	[256979] = {"blue","red"},
 	[258338] = "yellow",
 	[258381] = "red",
-	[264608] = "green",
-	[265088] = "green",
-	[265168] = {"blue","red"},
+	[264608] = {"blue","green","purple"},
+	[265088] = {"blue","green","purple"},
+	[265168] = {"blue","green","red"},
+	[267522] = "orange",
+	[267533] = "orange",
 })
 
 BigWigs:AddColors("Ring of Booty", {

--- a/BfA/Freehold/Options/Sounds.lua
+++ b/BfA/Freehold/Options/Sounds.lua
@@ -14,9 +14,11 @@ BigWigs:AddSounds("Council o' Captains", {
 	[256979] = "alert",
 	[258338] = "alert",
 	[258381] = "warning",
-	[264608] = "info",
-	[265088] = "info",
-	[265168] = "alarm",
+	[264608] = {"alarm","info"},
+	[265088] = {"alarm","info"},
+	[265168] = {"alarm","info"},
+	[267522] = "alert",
+	[267533] = "alert",
 })
 
 BigWigs:AddSounds("Ring of Booty", {

--- a/BfA/Freehold/Sweete.lua
+++ b/BfA/Freehold/Sweete.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Harlan Sweete", 1754, 2095)
 if not mod then return end
 mod:RegisterEnableMob(126983)
 mod.engageId = 2096
+mod.respawnTime = 15
 
 --------------------------------------------------------------------------------
 -- Initialization


### PR DESCRIPTION
Kragg:
 - Add initial dive bomb timer
 - Throttle Vile Bombardment damage for the first tick after it hits the ground. The first tick isn't needed now that there's a message for when Vile Bombardment is fired.

Captains:
 - Add Captain Jolly
 - Add personal messages and on boss messages for brews
 - Improve initial timers
 - Add respawn time

Booty:
 - Add respawn time

Sweete:
 - Add respawn time