### PR TITLE
BfA/TheMotherlode: Add Throw Coins, Pay to Win, and Azerite Catalyst

### DIFF
--- a/BfA/TheMotherlode/CrowdPummeler.lua
+++ b/BfA/TheMotherlode/CrowdPummeler.lua
@@ -19,6 +19,11 @@ function mod:GetOptions()
 		256493, -- Blazing Azerite
 		262347, -- Static Pulse
 		257337, -- Shocking Claw
+		{271784, "TANK"}, -- Throw Coins
+		271867, -- Pay to Win
+	}, {
+		[269493] = "general",
+		[271867] = "heroic",
 	}
 end
 
@@ -28,9 +33,13 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED_DOSE", "BlazingAzerite", 256493)
 	self:Log("SPELL_CAST_START", "StaticPulse", 262347)
 	self:Log("SPELL_CAST_START", "ShockingClaw", 257337)
+	self:Log("SPELL_CAST_SUCCESS", "ThrowCoins", 271784)
+	self:Log("SPELL_AURA_APPLIED", "PayToWin", 271867)
+	self:Log("SPELL_AURA_APPLIED_DOSE", "PayToWin", 271867)
 end
 
 function mod:OnEngage()
+	local coinMagnetCount = 1
 	self:Bar(262347, 6) -- Static Pulse
 	self:Bar(269493, 9.7) -- Footbomb Launcher
 	self:Bar(257337, 14.2) -- Shocking Claw
@@ -72,4 +81,35 @@ function mod:ShockingClaw(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm", "watchfront")
 	self:CDBar(args.spellId, 33)
+end
+
+do
+	local prev = 0
+	function mod:ThrowCoins(args)
+		local t = args.time
+		if t-prev > 5 then
+			prev = t
+			self:Message2(args.spellId, "yellow")
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
+end
+
+do
+	local stacks = 0
+	local timerStarted = false
+
+	local function warn()
+		timerStarted = false
+		mod:StackMessage(271867, UnitName("boss1"), stacks, "red") -- Coin Magnet
+		mod:PlaySound(271867, "alarm") -- Coin Magnet
+	end
+
+	function mod:PayToWin(args)
+		stacks = args.amount
+		if not timerStarted then
+			timerStarted = true
+			self:SimpleTimer(warn, 0.3)
+		end
+	end
 end

--- a/BfA/TheMotherlode/CrowdPummeler.lua
+++ b/BfA/TheMotherlode/CrowdPummeler.lua
@@ -39,7 +39,6 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	local coinMagnetCount = 1
 	self:Bar(262347, 6) -- Static Pulse
 	self:Bar(269493, 9.7) -- Footbomb Launcher
 	self:Bar(257337, 14.2) -- Shocking Claw

--- a/BfA/TheMotherlode/CrowdPummeler.lua
+++ b/BfA/TheMotherlode/CrowdPummeler.lua
@@ -100,7 +100,7 @@ do
 
 	local function warn()
 		timerStarted = false
-		mod:StackMessage(271867, UnitName("boss1"), stacks, "red") -- Coin Magnet
+		mod:StackMessage(271867, mod.displayName, stacks, "red") -- Coin Magnet
 		mod:PlaySound(271867, "alarm") -- Coin Magnet
 	end
 

--- a/BfA/TheMotherlode/CrowdPummeler.lua
+++ b/BfA/TheMotherlode/CrowdPummeler.lua
@@ -23,7 +23,7 @@ function mod:GetOptions()
 		271867, -- Pay to Win
 	}, {
 		[269493] = "general",
-		[271867] = "heroic",
+		[271784] = "heroic",
 	}
 end
 

--- a/BfA/TheMotherlode/Options/Colors.lua
+++ b/BfA/TheMotherlode/Options/Colors.lua
@@ -4,6 +4,8 @@ BigWigs:AddColors("Coin-Operated Crowd Pummeler", {
 	[257337] = "orange",
 	[262347] = "yellow",
 	[269493] = "cyan",
+	[271784] = "yellow",
+	[271867] = {"blue","red"},
 })
 
 BigWigs:AddColors("Tik'ali", {
@@ -17,7 +19,7 @@ BigWigs:AddColors("Tik'ali", {
 BigWigs:AddColors("Rixxa Fluxflame", {
 	[259853] = {"blue","orange"},
 	[260669] = {"blue","yellow"},
-	[270042] = "red",
+	[270028] = "red",
 })
 
 BigWigs:AddColors("Mogul Razzdunk", {

--- a/BfA/TheMotherlode/Options/Sounds.lua
+++ b/BfA/TheMotherlode/Options/Sounds.lua
@@ -4,6 +4,8 @@ BigWigs:AddSounds("Coin-Operated Crowd Pummeler", {
 	[257337] = "alarm",
 	[262347] = "alert",
 	[269493] = "long",
+	[271784] = "alert",
+	[271867] = "alarm",
 })
 
 BigWigs:AddSounds("Tik'ali", {
@@ -17,7 +19,7 @@ BigWigs:AddSounds("Tik'ali", {
 BigWigs:AddSounds("Rixxa Fluxflame", {
 	[259853] = "alarm",
 	[260669] = "alert",
-	[270042] = "long",
+	[270028] = "long",
 })
 
 BigWigs:AddSounds("Mogul Razzdunk", {

--- a/BfA/TheMotherlode/Razzdunk.lua
+++ b/BfA/TheMotherlode/Razzdunk.lua
@@ -19,7 +19,6 @@ function mod:GetOptions()
 		{260829, "ICON", "SAY"}, -- Homing Missile
 		276229, -- Micro Missiles
 		271456, -- Drill Smash
-		--270277, -- Big Red Rocket XXX Missing from logs, UNIT event?
 	}, {
 		[260280] = -18916, -- Stage One: Big Guns
 		[271456] = -17498, -- Stage Two: Drill!
@@ -33,7 +32,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "ConfigurationDrill", 260189)
 	self:Log("SPELL_CAST_START", "DrillSmash", 271456)
 	self:Log("SPELL_CAST_START", "MicroMissiles", 276229)
-	--self:Log("SPELL_CAST_START", "BigRedRocket", 270277)
 	self:Log("SPELL_CAST_SUCCESS", "ConfigurationCombat", 260190)
 
 end
@@ -75,6 +73,7 @@ function mod:ConfigurationDrill(args)
 	self:PlaySound("stages", "info")
 	self:StopBar(260829) -- Homing Missile
 	self:StopBar(260280) -- Gatling Gun
+	self:StopBar(CL.cast:format(self:SpellName(276229))) --  Micro Missiles Cast Bar
 end
 
 do
@@ -101,11 +100,6 @@ do
 		end
 	end
 end
-
--- function mod:BigRedRocket(args)
-	-- self:Message2(args.spellId, "yellow")
-	-- self:Playsound(args.spellId, "long")
--- end
 
 function mod:ConfigurationCombat(args)
 	self:Message2("stages", "cyan", args.spellName, args.spellId)

--- a/BfA/TheMotherlode/Rixxa.lua
+++ b/BfA/TheMotherlode/Rixxa.lua
@@ -76,7 +76,7 @@ do
 	function mod:ChemicalBurnApplied(args)
 		playerList[#playerList+1] = args.destName
 		if self:Me(args.destGUID) or self:Dispeller("magic") then
-			self:PlaySound(args.spellId, "alarm", self:Dispeller("magic") and "dispel", playerList)
+			self:PlaySound(args.spellId, "alarm", self:Dispeller("magic") and "dispel")
 		end
 		self:TargetsMessage(args.spellId, "orange", playerList, 2, nil, nil, 1)
 	end

--- a/BfA/TheMotherlode/Rixxa.lua
+++ b/BfA/TheMotherlode/Rixxa.lua
@@ -7,6 +7,14 @@ local mod, CL = BigWigs:NewBoss("Rixxa Fluxflame", 1594, 2115)
 if not mod then return end
 mod:RegisterEnableMob(129231)
 mod.engageId = 2107
+mod.respawnTime = 31
+
+--------------------------------------------------------------------------------
+-- Locals
+--
+
+local chemicalBurnCount = 0
+local azeriteCatalystCount = 0
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -14,21 +22,25 @@ mod.engageId = 2107
 
 function mod:GetOptions()
 	return {
-		270042, -- Agent Azerite
+		270028, -- Azerite Catalyst
 		259853, -- Chemical Burn
 		{260669, "SAY", "FLASH"}, -- Propellant Blast
 	}
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_CAST_SUCCESS", "AgentAzerite", 270042)
+	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1")
+
 	self:Log("SPELL_CAST_SUCCESS", "ChemicalBurnSuccess", 259856)
 	self:Log("SPELL_AURA_APPLIED", "ChemicalBurnApplied", 259853)
 	self:Log("SPELL_CAST_START", "PropellantBlast", 260669)
 end
 
 function mod:OnEngage()
-	self:Bar(270042, 8) -- Agent Azerite
+	chemicalBurnCount = 0
+	azeriteCatalystCount = 0
+	self:Bar(270028, 4) -- Azerite Catalyst
+	self:Bar(259853, 12.5) -- Chemical Burn
 	self:Bar(260669, 31) -- Propellant Blast
 end
 
@@ -36,22 +48,25 @@ end
 -- Event Handlers
 --
 
-function mod:AgentAzerite(args)
-	self:Message2(args.spellId, "red", CL.casting:format(args.spellName))
-	self:PlaySound(args.spellId, "long", "watchstep")
-	self:CDBar(args.spellId, 8)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
+	if spellId == 270028 then -- Azerite Catalyst
+		azeriteCatalystCount = azeriteCatalystCount + 1
+		self:Message2(spellId, "red", CL.casting:format(self:SpellName(spellId)))
+		self:PlaySound(spellId, "long", "watchstep")
+		-- Cooldown alternates between 15 and 27, starting with 15
+		self:Bar(spellId, azeriteCatalystCount % 2 == 1 and 15 or 27)
+	end
 end
 
 do
 	local prev = 0
-	local count = 0
 	function mod:ChemicalBurnSuccess(args)
 		local t = args.time
 		if t-prev > 2 then -- Ignore second cast
 			prev = t
-			count = count + 1
+			chemicalBurnCount = chemicalBurnCount + 1
 			-- Cooldown alternates between 15 and 27, starting with 15
-			self:Bar(259853, count % 2 == 1 and 15 or 27)
+			self:Bar(259853, chemicalBurnCount % 2 == 1 and 15 or 27)
 		end
 	end
 end
@@ -61,9 +76,9 @@ do
 	function mod:ChemicalBurnApplied(args)
 		playerList[#playerList+1] = args.destName
 		if self:Me(args.destGUID) or self:Dispeller("magic") then
-			self:PlaySound(args.spellId, "alarm", self:Dispeller("magic") and "dispel")
+			self:PlaySound(args.spellId, "alarm", self:Dispeller("magic") and "dispel", playerList)
 		end
-		self:TargetsMessage(args.spellId, "orange", playerList)
+		self:TargetsMessage(args.spellId, "orange", playerList, 2, nil, nil, 1)
 	end
 end
 
@@ -76,7 +91,7 @@ do
 		end
 		self:TargetMessage2(260669, "yellow", player)
 	end
-	
+
 	function mod:PropellantBlast(args)
 		local t = args.time
 		if t-prev > 10 then

--- a/BfA/TheMotherlode/Rixxa.lua
+++ b/BfA/TheMotherlode/Rixxa.lua
@@ -51,7 +51,7 @@ end
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 270028 then -- Azerite Catalyst
 		azeriteCatalystCount = azeriteCatalystCount + 1
-		self:Message2(spellId, "red", CL.casting:format(self:SpellName(spellId)))
+		self:Message2(spellId, "red")
 		self:PlaySound(spellId, "long", "watchstep")
 		-- Cooldown alternates between 15 and 27, starting with 15
 		self:Bar(spellId, azeriteCatalystCount % 2 == 1 and 15 or 27)

--- a/BfA/TheMotherlode/Tikali.lua
+++ b/BfA/TheMotherlode/Tikali.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Tik'ali", 1594, 2114)
 if not mod then return end
 mod:RegisterEnableMob(129227)
 mod.engageId = 2106
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -54,9 +55,12 @@ end
 
 do
 	local playerList = mod:NewTargetList()
+	local prev = 0
 	function mod:RagingGaze(args)
 		playerList[#playerList+1] = args.destName
-		if self:Me(args.destGUID) then
+		local t = args.time
+		if self:Me(args.destGUID) and t-prev > 0.3 then -- Only run once per targetsmessage
+			prev = t
 			self:PlaySound(args.spellId, "warning", "fixate")
 			self:Say(args.spellId)
 		end

--- a/BfA/TheMotherlode/Trash.lua
+++ b/BfA/TheMotherlode/Trash.lua
@@ -20,7 +20,7 @@ mod:RegisterEnableMob(
 	136470, -- Refreshment Vendor
 	130435, -- Addled Thug
 	137029, -- Ordnance Specialist
-	134012, -- Taskmaster Askari 
+	134012, -- Taskmaster Askari
 	133463, -- Venture Co. War Machine
 	136643  -- Azerite Extractor
 )
@@ -277,7 +277,6 @@ end
 function mod:TransmuteEnemyToGoo(args)
 	self:Message2(args.spellId, "red", CL.casting:format(args.spellName))
 	self:PlaySound(args.spellId, "warning", "interrupt")
-	self:TargetBar(args.spellId, 10, args.destName)
 end
 
 function mod:TransmuteEnemyToGooApplied(args)


### PR DESCRIPTION
CrowdPummeler:
- Add Throw Coin message
- Add Pay to Win stack message

Tikali:
- Throttle Raging Gaze say message

Rixxa:
- Add Azerite Catalyst
- Fix Chemical Burn targetsmessage
- Reset Chemical Burn counter on pull

Razzdunk:
- Stop micro missiles cast bar when intermission starts

Trash:
- Remove Transmute Enemy to Goo targetbar