### PR TITLE
BfA/WaycrestManor: Improvements

### DIFF
--- a/BfA/WaycrestManor/Goliath.lua
+++ b/BfA/WaycrestManor/Goliath.lua
@@ -53,7 +53,7 @@ function mod:SoulHarvest(args)
 end
 
 function mod:SoulThorns()
-	self:CDBar(267907, 22)
+	self:Bar(267907, 22)
 end
 
 do

--- a/BfA/WaycrestManor/Goliath.lua
+++ b/BfA/WaycrestManor/Goliath.lua
@@ -53,7 +53,7 @@ function mod:SoulHarvest(args)
 end
 
 function mod:SoulThorns()
-	self:Bar(267907, 22)
+	self:CDBar(267907, 22)
 end
 
 do

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -9,6 +9,23 @@ mod:RegisterEnableMob(131864)
 mod.engageId = 2117
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local slaverCorpseCount = 0
+
+--------------------------------------------------------------------------------
+-- Localization
+--
+
+local L = mod:GetLocale()
+if L then
+	L.add_killed = "Add killed, %d corpses remaining"
+	L.corpses_burned = "%d corpses burned, %d remaining"
+	L.adds_resurrected = "%d adds resurrected"
+end
+
+--------------------------------------------------------------------------------
 -- Initialization
 --
 
@@ -17,37 +34,59 @@ function mod:GetOptions()
 		266181, -- Dread Essence
 		266266, -- Summon Deathtouched Slaver
 		266225, -- Darkened Lightning
-		266198, -- Alchemical Fire -- XXX Didn't work in my normal run (no log)
+		266198, -- Alchemical Fire
+		268202, -- Death Lens
+	}, {
+		[266181] = "general",
+		[268202] = "heroic",
 	}
 end
 
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "DreadEssence", 266181)
+	self:Log("SPELL_CAST_SUCCESS", "DreadEssenceSuccess", 266181)
 	self:Log("SPELL_CAST_SUCCESS", "SummonDeathtouchedSlaver", 266266)
 	self:Log("SPELL_CAST_START", "DarkenedLightning", 266225)
 	self:Log("SPELL_CAST_SUCCESS", "AlchemicalFire", 266198)
+	self:Log("SPELL_CAST_SUCCESS", "DeathLens", 268202)
+	self:Death("DeathtouchedSlaverDeath", 135552)
 end
 
 function mod:OnEngage()
-	self:Bar(266225, 9) -- Darkened Lightning
-	self:Bar(266266, 17) -- Summon Deathtouched Slaver
-	self:Bar(266181, 27.5) -- Dread Essence
+	slaverCorpseCount = 0
+	self:Bar(266266, 4.4) -- Summon Deathtouched Slaver
+	self:Bar(266225, 7.2) -- Darkened Lightning
+	self:Bar(266181, 26.7) -- Dread Essence
 end
 
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
 
+function mod:DeathtouchedSlaverDeath(args)
+	slaverCorpseCount = slaverCorpseCount + 1
+	self:Message2(266198, "orange", L.add_killed:format(slaverCorpseCount))
+	self:PlaySound(266198, "info")
+end
+
 function mod:DreadEssence(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
-	self:Bar(args.spellId, 27.5)
+	self:Bar(args.spellId, 28)
+end
+
+function mod:DreadEssenceSuccess(args)
+	if slaverCorpseCount > 0 then
+		self:Message2(args.spellId, "orange", L.adds_resurrected:format(slaverCorpseCount))
+		self:PlaySound(args.spellId, "info")
+	end
+	slaverCorpseCount = 0
 end
 
 function mod:SummonDeathtouchedSlaver(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "info")
-	self:Bar(args.spellId, 27.5)
+	self:CDBar(args.spellId, 17)
 end
 
 function mod:DarkenedLightning(args)
@@ -58,7 +97,24 @@ function mod:DarkenedLightning(args)
 	self:Bar(args.spellId, 14.5)
 end
 
-function mod:AlchemicalFire(args)
-	self:Message2(args.spellId, "green")
-	self:PlaySound(args.spellId, "long")
+do
+	local burnCount = 0
+	local function warn()
+		burnCount = 0
+		mod:Message2(266198, "green", L.corpses_burned:format(burnCount, slaverCorpseCount)) -- Alchemical Fire
+		mod:PlaySound(266198, "long") -- Alchemical Fire
+	end
+
+	function mod:AlchemicalFire(args)
+		slaverCorpseCount = slaverCorpseCount - 1
+		burnCount = burnCount + 1
+		if burnCount == 1 then
+			self:SimpleTimer(warn, 0.1)
+		end
+	end
+end
+
+function mod:DeathLens(args)
+	self:TargetMessage2(args.spellId, "red", args.destName)
+	self:PlaySound(args.spellId, "alert")
 end

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -15,7 +15,7 @@ mod.respawnTime = 15
 
 local L = mod:GetLocale()
 if L then
-	L.add_killed = "Add killed"
+	L.add_killed = "Add killed - Ready to burn"
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -48,7 +48,7 @@ end
 function mod:OnEngage()
 	self:Bar(266266, 4.4) -- Summon Deathtouched Slaver
 	self:Bar(266225, 7.2) -- Darkened Lightning
-	self:Bar(266181, 25.5) -- Dread Essence
+	self:CDBar(266181, 25.5) -- Dread Essence
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -8,6 +8,16 @@ if not mod then return end
 mod:RegisterEnableMob(131864)
 mod.engageId = 2117
 
+
+--------------------------------------------------------------------------------
+-- Localization
+--
+
+local L = mod:GetLocale()
+if L then
+	L.add_killed = "Add killed"
+end
+
 --------------------------------------------------------------------------------
 -- Initialization
 --
@@ -31,6 +41,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "DarkenedLightning", 266225)
 	self:Log("SPELL_CAST_SUCCESS", "AlchemicalFire", 266198)
 	self:Log("SPELL_CAST_SUCCESS", "DeathLens", 268202)
+
+	self:Death("DeathtouchedSlaverDeath", 135552)
 end
 
 function mod:OnEngage()
@@ -71,4 +83,9 @@ end
 function mod:DeathLens(args)
 	self:TargetMessage2(args.spellId, "red", args.destName)
 	self:PlaySound(args.spellId, "alert", nil, args.destName)
+end
+
+function mod:DeathtouchedSlaverDeath(args)
+	self:Message2(266198, "yellow", L.add_killed) -- Alchemical Fire
+	self:PlaySound(266198, "info") -- Alchemical Fire
 end

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -58,7 +58,7 @@ end
 function mod:DreadEssence(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
-	self:Bar(args.spellId, 28)
+	self:CDBar(args.spellId, 28)
 end
 
 function mod:SummonDeathtouchedSlaver(args)
@@ -72,7 +72,7 @@ function mod:DarkenedLightning(args)
 		self:Message2(args.spellId, "orange")
 		self:PlaySound(args.spellId, "alert")
 	end
-	self:Bar(args.spellId, 15.8)
+	self:CDBar(args.spellId, 15.8)
 end
 
 function mod:AlchemicalFire(args)

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -68,8 +68,8 @@ function mod:SummonDeathtouchedSlaver(args)
 end
 
 function mod:DarkenedLightning(args)
-	self:Message2(args.spellId, "orange")
 	if self:Interrupter() then
+		self:Message2(args.spellId, "orange")
 		self:PlaySound(args.spellId, "alert")
 	end
 	self:Bar(args.spellId, 15.8)

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -9,23 +9,6 @@ mod:RegisterEnableMob(131864)
 mod.engageId = 2117
 
 --------------------------------------------------------------------------------
--- Locals
---
-
-local slaverCorpseCount = 0
-
---------------------------------------------------------------------------------
--- Localization
---
-
-local L = mod:GetLocale()
-if L then
-	L.add_killed = "Add killed, %d corpses remaining"
-	L.corpses_burned = "%d corpses burned, %d remaining"
-	L.adds_resurrected = "%d adds resurrected"
-end
-
---------------------------------------------------------------------------------
 -- Initialization
 --
 
@@ -34,59 +17,37 @@ function mod:GetOptions()
 		266181, -- Dread Essence
 		266266, -- Summon Deathtouched Slaver
 		266225, -- Darkened Lightning
-		266198, -- Alchemical Fire
-		268202, -- Death Lens
-	}, {
-		[266181] = "general",
-		[268202] = "heroic",
+		266198, -- Alchemical Fire -- XXX Didn't work in my normal run (no log)
 	}
 end
 
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "DreadEssence", 266181)
-	self:Log("SPELL_CAST_SUCCESS", "DreadEssenceSuccess", 266181)
 	self:Log("SPELL_CAST_SUCCESS", "SummonDeathtouchedSlaver", 266266)
 	self:Log("SPELL_CAST_START", "DarkenedLightning", 266225)
 	self:Log("SPELL_CAST_SUCCESS", "AlchemicalFire", 266198)
-	self:Log("SPELL_CAST_SUCCESS", "DeathLens", 268202)
-	self:Death("DeathtouchedSlaverDeath", 135552)
 end
 
 function mod:OnEngage()
-	slaverCorpseCount = 0
-	self:Bar(266266, 4.4) -- Summon Deathtouched Slaver
-	self:Bar(266225, 7.2) -- Darkened Lightning
-	self:Bar(266181, 26.7) -- Dread Essence
+	self:Bar(266225, 9) -- Darkened Lightning
+	self:Bar(266266, 17) -- Summon Deathtouched Slaver
+	self:Bar(266181, 27.5) -- Dread Essence
 end
 
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
 
-function mod:DeathtouchedSlaverDeath(args)
-	slaverCorpseCount = slaverCorpseCount + 1
-	self:Message2(266198, "orange", L.add_killed:format(slaverCorpseCount))
-	self:PlaySound(266198, "info")
-end
-
 function mod:DreadEssence(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
-	self:Bar(args.spellId, 28)
-end
-
-function mod:DreadEssenceSuccess(args)
-	if slaverCorpseCount > 0 then
-		self:Message2(args.spellId, "orange", L.adds_resurrected:format(slaverCorpseCount))
-		self:PlaySound(args.spellId, "info")
-	end
-	slaverCorpseCount = 0
+	self:Bar(args.spellId, 27.5)
 end
 
 function mod:SummonDeathtouchedSlaver(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "info")
-	self:CDBar(args.spellId, 17)
+	self:Bar(args.spellId, 27.5)
 end
 
 function mod:DarkenedLightning(args)
@@ -97,24 +58,7 @@ function mod:DarkenedLightning(args)
 	self:Bar(args.spellId, 14.5)
 end
 
-do
-	local burnCount = 0
-	local function warn()
-		burnCount = 0
-		mod:Message2(266198, "green", L.corpses_burned:format(burnCount, slaverCorpseCount)) -- Alchemical Fire
-		mod:PlaySound(266198, "long") -- Alchemical Fire
-	end
-
-	function mod:AlchemicalFire(args)
-		slaverCorpseCount = slaverCorpseCount - 1
-		burnCount = burnCount + 1
-		if burnCount == 1 then
-			self:SimpleTimer(warn, 0.1)
-		end
-	end
-end
-
-function mod:DeathLens(args)
-	self:TargetMessage2(args.spellId, "red", args.destName)
-	self:PlaySound(args.spellId, "alert", nil, args.destName)
+function mod:AlchemicalFire(args)
+	self:Message2(args.spellId, "green")
+	self:PlaySound(args.spellId, "long")
 end

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -48,7 +48,7 @@ end
 function mod:OnEngage()
 	self:Bar(266266, 4.4) -- Summon Deathtouched Slaver
 	self:Bar(266225, 7.2) -- Darkened Lightning
-	self:Bar(266181, 26.7) -- Dread Essence
+	self:Bar(266181, 25.5) -- Dread Essence
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -7,7 +7,7 @@ local mod, CL = BigWigs:NewBoss("Gorak Tul", 1862, 2129)
 if not mod then return end
 mod:RegisterEnableMob(131864)
 mod.engageId = 2117
-
+mod.respawnTime = 15
 
 --------------------------------------------------------------------------------
 -- Localization

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -72,7 +72,7 @@ function mod:DarkenedLightning(args)
 	if self:Interrupter() then
 		self:PlaySound(args.spellId, "alert")
 	end
-	self:Bar(args.spellId, 14.5)
+	self:Bar(args.spellId, 15.8)
 end
 
 function mod:AlchemicalFire(args)

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -116,5 +116,5 @@ end
 
 function mod:DeathLens(args)
 	self:TargetMessage2(args.spellId, "red", args.destName)
-	self:PlaySound(args.spellId, "alert")
+	self:PlaySound(args.spellId, "alert", nil, args.destName)
 end

--- a/BfA/WaycrestManor/GorakTul.lua
+++ b/BfA/WaycrestManor/GorakTul.lua
@@ -17,7 +17,11 @@ function mod:GetOptions()
 		266181, -- Dread Essence
 		266266, -- Summon Deathtouched Slaver
 		266225, -- Darkened Lightning
-		266198, -- Alchemical Fire -- XXX Didn't work in my normal run (no log)
+		266198, -- Alchemical Fire
+		268202, -- Death Lens
+	}, {
+		[266181] = "general",
+		[268202] = "heroic",
 	}
 end
 
@@ -26,12 +30,13 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "SummonDeathtouchedSlaver", 266266)
 	self:Log("SPELL_CAST_START", "DarkenedLightning", 266225)
 	self:Log("SPELL_CAST_SUCCESS", "AlchemicalFire", 266198)
+	self:Log("SPELL_CAST_SUCCESS", "DeathLens", 268202)
 end
 
 function mod:OnEngage()
-	self:Bar(266225, 9) -- Darkened Lightning
-	self:Bar(266266, 17) -- Summon Deathtouched Slaver
-	self:Bar(266181, 27.5) -- Dread Essence
+	self:Bar(266266, 4.4) -- Summon Deathtouched Slaver
+	self:Bar(266225, 7.2) -- Darkened Lightning
+	self:Bar(266181, 26.7) -- Dread Essence
 end
 
 --------------------------------------------------------------------------------
@@ -41,13 +46,13 @@ end
 function mod:DreadEssence(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "warning")
-	self:Bar(args.spellId, 27.5)
+	self:Bar(args.spellId, 28)
 end
 
 function mod:SummonDeathtouchedSlaver(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "info")
-	self:Bar(args.spellId, 27.5)
+	self:CDBar(args.spellId, 17)
 end
 
 function mod:DarkenedLightning(args)
@@ -61,4 +66,9 @@ end
 function mod:AlchemicalFire(args)
 	self:Message2(args.spellId, "green")
 	self:PlaySound(args.spellId, "long")
+end
+
+function mod:DeathLens(args)
+	self:TargetMessage2(args.spellId, "red", args.destName)
+	self:PlaySound(args.spellId, "alert", nil, args.destName)
 end

--- a/BfA/WaycrestManor/Heartsbane.lua
+++ b/BfA/WaycrestManor/Heartsbane.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Heartsbane Triad", 1862, 2125)
 if not mod then return end
 mod:RegisterEnableMob(131825, 131823, 131824) -- Sister Briar, Sister Malady, Sister Solena
 mod.engageId = 2113
+mod.respawnTime = 20
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/WaycrestManor/Locales/deDE.lua
+++ b/BfA/WaycrestManor/Locales/deDE.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Gezeichnete Schwester"
 	L.alma = "Matrone Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "deDE")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/deDE.lua
+++ b/BfA/WaycrestManor/Locales/deDE.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Gezeichnete Schwester"
 	L.alma = "Matrone Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "deDE")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/deDE.lua
+++ b/BfA/WaycrestManor/Locales/deDE.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "deDE")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/deDE.lua
+++ b/BfA/WaycrestManor/Locales/deDE.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Gezeichnete Schwester"
 	L.alma = "Matrone Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "deDE")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/esES.lua
+++ b/BfA/WaycrestManor/Locales/esES.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Hermana marcada"
 	L.alma = "Matriarca Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "esES") or BigWigs:NewBossLocale("Gorak Tul", "esMX")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/esES.lua
+++ b/BfA/WaycrestManor/Locales/esES.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "esES") or BigWigs:NewBossLocale("Gorak Tul", "esMX")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/esES.lua
+++ b/BfA/WaycrestManor/Locales/esES.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Hermana marcada"
 	L.alma = "Matriarca Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "esES") or BigWigs:NewBossLocale("Gorak Tul", "esMX")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/esES.lua
+++ b/BfA/WaycrestManor/Locales/esES.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Hermana marcada"
 	L.alma = "Matriarca Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "esES") or BigWigs:NewBossLocale("Gorak Tul", "esMX")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/frFR.lua
+++ b/BfA/WaycrestManor/Locales/frFR.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Soeur marquée"
 	L.alma = "Matrone Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "frFR")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/frFR.lua
+++ b/BfA/WaycrestManor/Locales/frFR.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Soeur marquée"
 	L.alma = "Matrone Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "frFR")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/frFR.lua
+++ b/BfA/WaycrestManor/Locales/frFR.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Soeur marquée"
 	L.alma = "Matrone Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "frFR")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/frFR.lua
+++ b/BfA/WaycrestManor/Locales/frFR.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "frFR")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/itIT.lua
+++ b/BfA/WaycrestManor/Locales/itIT.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "itIT")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/itIT.lua
+++ b/BfA/WaycrestManor/Locales/itIT.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Sorella Marchiata"
 	L.alma = "Matrona Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "itIT")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/itIT.lua
+++ b/BfA/WaycrestManor/Locales/itIT.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Sorella Marchiata"
 	L.alma = "Matrona Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "itIT")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/itIT.lua
+++ b/BfA/WaycrestManor/Locales/itIT.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Sorella Marchiata"
 	L.alma = "Matrona Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "itIT")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/koKR.lua
+++ b/BfA/WaycrestManor/Locales/koKR.lua
@@ -18,3 +18,8 @@ if L then
 	-- L.sister = "Marked Sister"
 	-- L.alma = "Matron Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "koKR")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/koKR.lua
+++ b/BfA/WaycrestManor/Locales/koKR.lua
@@ -18,3 +18,10 @@ if L then
 	-- L.sister = "Marked Sister"
 	-- L.alma = "Matron Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "koKR")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/koKR.lua
+++ b/BfA/WaycrestManor/Locales/koKR.lua
@@ -18,10 +18,3 @@ if L then
 	-- L.sister = "Marked Sister"
 	-- L.alma = "Matron Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "koKR")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/koKR.lua
+++ b/BfA/WaycrestManor/Locales/koKR.lua
@@ -1,22 +1,22 @@
 local L = BigWigs:NewBossLocale("Waycrest Manor Trash", "koKR")
 if not L then return end
 if L then
-	-- L.steward = "Banquet Steward"
-	-- L.gorger = "Pallid Gorger"
-	-- L.marksman = "Crazed Marksman"
-	-- L.runeweaver = "Heartsbane Runeweaver"
+	L.steward = "연회 집사"
+	L.gorger = "창백한 탐식자"
+	L.marksman = "광기 어린 명사수"
+	L.runeweaver = "심장파멸 룬마술사"
 	L.vinetwister = "심장파멸 덩굴왜곡사"
-	-- L.survivalist = "Maddened Survivalist"
-	-- L.bryndle = "Matron Bryndle"
-	-- L.thornshaper = "Coven Thornshaper"
-	-- L.thornguard = "Thornguard"
-	-- L.toad = "Blight Toad"
-	-- L.raven = "Dreadwing Raven"
-	-- L.soulcharmer = "Heartsbane Soulcharmer"
-	-- L.captain = "Bewitched Captain"
-	-- L.disciple = "Runic Disciple"
-	-- L.sister = "Marked Sister"
-	-- L.alma = "Matron Alma"
+	L.survivalist = "광기의 생존주의자"
+	L.bryndle = "대모 브린들"
+	L.thornshaper = "서약단 가시장이"
+	L.thornguard = "가시방어병"
+	L.toad = "역병 두꺼비"
+	L.raven = "공포날개 까마귀"
+	L.soulcharmer = "심장파멸 영혼매혹사"
+	L.captain = "혼이 빠져나간 대장"
+	L.disciple = "룬 신도"
+	L.sister = "징표 찍힌 자매"
+	L.alma = "대모 알마"
 end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "koKR")

--- a/BfA/WaycrestManor/Locales/koKR.lua
+++ b/BfA/WaycrestManor/Locales/koKR.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "koKR")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/ptBR.lua
+++ b/BfA/WaycrestManor/Locales/ptBR.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Irmã Marcada"
 	L.alma = "Máter Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "ptBR")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/ptBR.lua
+++ b/BfA/WaycrestManor/Locales/ptBR.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "ptBR")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/ptBR.lua
+++ b/BfA/WaycrestManor/Locales/ptBR.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Irmã Marcada"
 	L.alma = "Máter Alma"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "ptBR")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/ptBR.lua
+++ b/BfA/WaycrestManor/Locales/ptBR.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Irmã Marcada"
 	L.alma = "Máter Alma"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "ptBR")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/ruRU.lua
+++ b/BfA/WaycrestManor/Locales/ruRU.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "Меченая сестра"
 	L.alma = "Матрона Альма"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "ruRU")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/ruRU.lua
+++ b/BfA/WaycrestManor/Locales/ruRU.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "Меченая сестра"
 	L.alma = "Матрона Альма"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "ruRU")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/ruRU.lua
+++ b/BfA/WaycrestManor/Locales/ruRU.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "ruRU")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/ruRU.lua
+++ b/BfA/WaycrestManor/Locales/ruRU.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "Меченая сестра"
 	L.alma = "Матрона Альма"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "ruRU")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/zhCN.lua
+++ b/BfA/WaycrestManor/Locales/zhCN.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "显眼的女巫"
 	L.alma = "主母阿尔玛"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "zhCN")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/zhCN.lua
+++ b/BfA/WaycrestManor/Locales/zhCN.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "显眼的女巫"
 	L.alma = "主母阿尔玛"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "zhCN")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Locales/zhCN.lua
+++ b/BfA/WaycrestManor/Locales/zhCN.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "显眼的女巫"
 	L.alma = "主母阿尔玛"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "zhCN")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/zhCN.lua
+++ b/BfA/WaycrestManor/Locales/zhCN.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "zhCN")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/zhTW.lua
+++ b/BfA/WaycrestManor/Locales/zhTW.lua
@@ -18,3 +18,10 @@ if L then
 	L.sister = "符印女巫"
 	L.alma = "高階女巫艾爾瑪"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "zhTW")
+if L then
+	-- L.add_killed = "Add killed, %d corpses remaining"
+	-- L.corpses_burned = "%d corpses burned, %d remaining"
+	-- L.adds_resurrected = "%d adds resurrected"
+end

--- a/BfA/WaycrestManor/Locales/zhTW.lua
+++ b/BfA/WaycrestManor/Locales/zhTW.lua
@@ -18,3 +18,8 @@ if L then
 	L.sister = "符印女巫"
 	L.alma = "高階女巫艾爾瑪"
 end
+
+L = BigWigs:NewBossLocale("Gorak Tul", "zhTW")
+if L then
+	-- L.add_killed = "Add killed"
+end

--- a/BfA/WaycrestManor/Locales/zhTW.lua
+++ b/BfA/WaycrestManor/Locales/zhTW.lua
@@ -21,5 +21,5 @@ end
 
 L = BigWigs:NewBossLocale("Gorak Tul", "zhTW")
 if L then
-	-- L.add_killed = "Add killed"
+	-- L.add_killed = "Add killed - Ready to burn"
 end

--- a/BfA/WaycrestManor/Locales/zhTW.lua
+++ b/BfA/WaycrestManor/Locales/zhTW.lua
@@ -18,10 +18,3 @@ if L then
 	L.sister = "符印女巫"
 	L.alma = "高階女巫艾爾瑪"
 end
-
-L = BigWigs:NewBossLocale("Gorak Tul", "zhTW")
-if L then
-	-- L.add_killed = "Add killed, %d corpses remaining"
-	-- L.corpses_burned = "%d corpses burned, %d remaining"
-	-- L.adds_resurrected = "%d adds resurrected"
-end

--- a/BfA/WaycrestManor/Options/Colors.lua
+++ b/BfA/WaycrestManor/Options/Colors.lua
@@ -32,10 +32,11 @@ BigWigs:AddColors("Lord and Lady Waycrest", {
 })
 
 BigWigs:AddColors("Gorak Tul", {
-	[266181] = "red",
-	[266198] = "green",
+	[266181] = {"orange","red"},
+	[266198] = {"green","orange"},
 	[266225] = "orange",
 	[266266] = "yellow",
+	[268202] = {"blue","red"},
 })
 
 BigWigs:AddColors("Waycrest Manor Trash", {
@@ -65,4 +66,5 @@ BigWigs:AddColors("Waycrest Manor Trash", {
 	[265880] = "orange",
 	[265881] = "yellow",
 	[271174] = "yellow",
+	[278474] = "red",
 })

--- a/BfA/WaycrestManor/Options/Colors.lua
+++ b/BfA/WaycrestManor/Options/Colors.lua
@@ -28,7 +28,9 @@ BigWigs:AddColors("Lord and Lady Waycrest", {
 	[261438] = "yellow",
 	[261440] = {"blue","red"},
 	[261447] = {"blue","cyan"},
+	[268278] = "red",
 	[268306] = "orange",
+	["stages"] = "cyan",
 })
 
 BigWigs:AddColors("Gorak Tul", {

--- a/BfA/WaycrestManor/Options/Colors.lua
+++ b/BfA/WaycrestManor/Options/Colors.lua
@@ -21,7 +21,7 @@ BigWigs:AddColors("Raal the Gluttonous", {
 	[264734] = "orange",
 	[264923] = "red",
 	[264931] = "yellow",
-	[265002] = "orange",
+	[265005] = {"blue","orange"},
 })
 
 BigWigs:AddColors("Lord and Lady Waycrest", {

--- a/BfA/WaycrestManor/Options/Colors.lua
+++ b/BfA/WaycrestManor/Options/Colors.lua
@@ -32,8 +32,8 @@ BigWigs:AddColors("Lord and Lady Waycrest", {
 })
 
 BigWigs:AddColors("Gorak Tul", {
-	[266181] = {"orange","red"},
-	[266198] = {"green","orange"},
+	[266181] = "red",
+	[266198] = {"green","yellow"},
 	[266225] = "orange",
 	[266266] = "yellow",
 	[268202] = {"blue","red"},

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -32,10 +32,11 @@ BigWigs:AddSounds("Lord and Lady Waycrest", {
 })
 
 BigWigs:AddSounds("Gorak Tul", {
-	[266181] = "warning",
-	[266198] = "long",
+	[266181] = {"info","warning"},
+	[266198] = {"info","long"},
 	[266225] = "alert",
 	[266266] = "info",
+	[268202] = "alert",
 })
 
 BigWigs:AddSounds("Waycrest Manor Trash", {
@@ -65,4 +66,5 @@ BigWigs:AddSounds("Waycrest Manor Trash", {
 	[265880] = "alarm",
 	[265881] = "alert",
 	[271174] = "alert",
+	[278474] = "alert",
 })

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -21,7 +21,7 @@ BigWigs:AddSounds("Raal the Gluttonous", {
 	[264734] = "warning",
 	[264923] = "warning",
 	[264931] = "long",
-	[265002] = "alert",
+	[265005] = "alert",
 })
 
 BigWigs:AddSounds("Lord and Lady Waycrest", {

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -32,7 +32,7 @@ BigWigs:AddSounds("Lord and Lady Waycrest", {
 })
 
 BigWigs:AddSounds("Gorak Tul", {
-	[266181] = {"info","warning"},
+	[266181] = "warning",
 	[266198] = {"info","long"},
 	[266225] = "alert",
 	[266266] = "info",

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -30,7 +30,7 @@ BigWigs:AddSounds("Lord and Lady Waycrest", {
 	[261447] = "info",
 	[268278] = "alert",
 	[268306] = "alarm",
-	["stages"] = "long",
+	["stages"] = {"info","long"},
 })
 
 BigWigs:AddSounds("Gorak Tul", {

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -28,7 +28,9 @@ BigWigs:AddSounds("Lord and Lady Waycrest", {
 	[261438] = "alert",
 	[261440] = "warning",
 	[261447] = "info",
+	[268278] = "alert",
 	[268306] = "alarm",
+	["stages"] = "long",
 })
 
 BigWigs:AddSounds("Gorak Tul", {

--- a/BfA/WaycrestManor/Raal.lua
+++ b/BfA/WaycrestManor/Raal.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Raal the Gluttonous", 1862, 2127)
 if not mod then return end
 mod:RegisterEnableMob(131863)
 mod.engageId = 2115
+mod.respawnTime = 20
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/WaycrestManor/Raal.lua
+++ b/BfA/WaycrestManor/Raal.lua
@@ -24,7 +24,7 @@ function mod:GetOptions()
 	return {
 		264734, -- Consume All
 		264931, -- Call Servant
-		265002, -- Consume Servants
+		265005, -- Consumed Servant
 		264923, -- Tenderize
 		264694, -- Rotten Expulsion
 	}
@@ -33,7 +33,8 @@ end
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "ConsumeAll", 264734)
 	self:Log("SPELL_CAST_START", "CallServant", 264931)
-	self:Log("SPELL_CAST_START", "ConsumeServants", 265002)
+	self:Log("SPELL_AURA_APPLIED", "ConsumedServant", 265005)
+	self:Log("SPELL_AURA_APPLIED_DOSE", "ConsumedServant", 265005)
 	self:Log("SPELL_CAST_START", "Tenderize", 264923)
 	self:Log("SPELL_CAST_START", "RottenExpulsion", 264694)
 	self:Log("SPELL_AURA_APPLIED", "RottenExpulsionDamage", 264712)
@@ -65,8 +66,8 @@ function mod:CallServant(args)
 	self:Bar(args.spellId, 29)
 end
 
-function mod:ConsumeServants(args)
-	self:Message2(args.spellId, "orange")
+function mod:ConsumedServant(args)
+	self:StackMessage(args.spellId, args.destName, args.amount, "orange")
 	self:PlaySound(args.spellId, "alert")
 end
 

--- a/BfA/WaycrestManor/Trash.lua
+++ b/BfA/WaycrestManor/Trash.lua
@@ -75,6 +75,7 @@ function mod:GetOptions()
 		265741, -- Drain Soul Essence
 		-- Coven Thornshaper
 		264050, -- Infected Thorn
+		278474, -- Effigy Reconstruction
 		{264038, "SAY"}, -- Uproot
 		-- Thornguard
 		264556, -- Tearing Strike
@@ -142,6 +143,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "DrainSoulEssence", 265741)
 	-- Coven Thornshaper
 	self:Log("SPELL_CAST_START", "InfectedThorn", 264050)
+	self:Log("SPELL_CAST_START", "EffigyReconstruction", 278474)
 	self:Log("SPELL_CAST_START", "Uproot", 264038)
 	-- Thornguard
 	self:Log("SPELL_AURA_APPLIED", "TearingStrike", 264556)
@@ -256,8 +258,20 @@ function mod:DrainSoulEssence(args)
 end
 
 -- Coven Thornshaper
-function mod:InfectedThorn(args)
-	self:Message2(args.spellId, "yellow")
+do
+	local prev = 0
+	function mod:InfectedThorn(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			prev = t
+			self:Message2(args.spellId, "yellow")
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
+end
+
+function mod:EffigyReconstruction(args)
+	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "alert")
 end
 

--- a/BfA/WaycrestManor/Trash.lua
+++ b/BfA/WaycrestManor/Trash.lua
@@ -184,9 +184,16 @@ function mod:DinnerBell(args)
 end
 
 -- Pallid Gorger
-function mod:Retch(args)
-	self:Message2(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
+do
+	local prev = 0
+	function mod:Retch(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			prev = t
+			self:Message2(args.spellId, "yellow")
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
 end
 
 -- Crazed Marksman

--- a/BfA/WaycrestManor/Trash.lua
+++ b/BfA/WaycrestManor/Trash.lua
@@ -178,9 +178,16 @@ end
 --
 
 -- Banquet Steward
-function mod:DinnerBell(args)
-	self:Message2(args.spellId, "orange")
-	self:PlaySound(args.spellId, "warning")
+do
+	local prev = 0
+	function mod:DinnerBell(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			prev = t
+			self:Message2(args.spellId, "orange")
+			self:PlaySound(args.spellId, "warning")
+		end
+	end
 end
 
 -- Pallid Gorger

--- a/BfA/WaycrestManor/Trash.lua
+++ b/BfA/WaycrestManor/Trash.lua
@@ -245,14 +245,28 @@ function mod:GraspingThornsRemoved(args)
 end
 
 -- Maddened Survivalist
-function mod:ShrapnelTrap(args)
-	self:Message2(args.spellId, "red")
-	self:PlaySound(args.spellId, "alarm")
+do
+	local prev = 0
+	function mod:ShrapnelTrap(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			prev = t
+			self:Message2(args.spellId, "red")
+			self:PlaySound(args.spellId, "alarm")
+		end
+	end
 end
 
-function mod:SeveringSerpent(args)
-	self:Message2(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
+do
+	local prev = 0
+	function mod:SeveringSerpent(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			prev = t
+			self:Message2(args.spellId, "yellow")
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
 end
 
 -- Matron Bryndle

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -46,6 +46,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "VirulentPathogenRemoved", 261440)
 	self:Log("SPELL_AURA_APPLIED", "PutridVitality", 261447)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "PutridVitality", 261447)
+	self:Log("SPELL_AURA_REMOVED", "SoulArmorRemoved", 271590)
 end
 
 function mod:OnEngage()
@@ -64,8 +65,8 @@ function mod:VitalityTransfer(args)
 	vitalityTransferCount = vitalityTransferCount + 1
 	if vitalityTransferCount == 3 then
 		stage = 2
-		self:Message2("stages", "cyan", CL.incoming:format(self:SpellName(-17773)), false) -- Lady Waycrest
-		self:PlaySound("stages", "long")
+		self:Message2("stages", "cyan", CL.soon:format(self:SpellName(-17773)), false) -- Lady Waycrest
+		self:PlaySound("stages", "info")
 	end
 end
 
@@ -129,4 +130,9 @@ end
 function mod:PutridVitality(args)
 	self:StackMessage(args.spellId, args.destName, args.amount, "cyan")
 	self:PlaySound(args.spellId, "info")
+end
+
+function mod:SoulArmorRemoved(args)
+	self:Message2("stages", "cyan", self:SpellName(-17773), false) -- Lady Waycrest
+	self:PlaySound("stages", "long")
 end

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -64,7 +64,7 @@ function mod:VitalityTransfer(args)
 	vitalityTransferCount = vitalityTransferCount + 1
 	if vitalityTransferCount == 3 then
 		stage = 2
-		self:Message2("stages", "cyan", CL.incoming:format(self:SpellName(-17773))) -- Lady Waycrest
+		self:Message2("stages", "cyan", CL.incoming:format(self:SpellName(-17773)), false) -- Lady Waycrest
 		self:PlaySound("stages", "long")
 	end
 end

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -28,7 +28,7 @@ function mod:GetOptions()
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_CAST_START", "DiscordantCadenza", 268306)
+	self:Log("SPELL_CAST_SUCCESS", "DiscordantCadenza", 268306)
 	self:Log("SPELL_CAST_SUCCESS", "WastingStrike", 261438)
 	self:Log("SPELL_CAST_SUCCESS", "VirulentPathogen", 261440)
 	self:Log("SPELL_AURA_APPLIED", "VirulentPathogenApplied", 261440)

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -46,7 +46,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_REMOVED", "VirulentPathogenRemoved", 261440)
 	self:Log("SPELL_AURA_APPLIED", "PutridVitality", 261447)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "PutridVitality", 261447)
-	self:Log("SPELL_AURA_REMOVED", "SoulArmorRemoved", 271590)
 end
 
 function mod:OnEngage()

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -76,9 +76,12 @@ function mod:DiscordantCadenza(args)
 end
 
 function mod:WrackingChord(args)
-	if stage == 2 and self:Interrupter() then
-		self:Message2(args.spellId, "red")
-		self:PlaySound(args.spellId, "alert")
+	if stage == 2 then
+		if self:Interrupter() then
+			self:Message2(args.spellId, "red")
+			self:PlaySound(args.spellId, "alert")
+		end
+		self:CDBar(args.spellId, 8)
 	end
 end
 

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -72,7 +72,7 @@ do
 			stage = 2
 			self:Message2("stages", "cyan", CL.soon:format(self:SpellName(-17773)), false) -- Lady Waycrest
 			self:PlaySound("stages", "info")
-			self:Bar("stages", 6, CL.incoming:format(self:SpellName(-17773)), false)
+			self:Bar("stages", 6, CL.incoming:format(self:SpellName(-17773)), "achievement_character_undead_female")
 			self:SimpleTimer(warnLadyWacrest, 6)
 		end
 	end

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -61,12 +61,21 @@ end
 -- Event Handlers
 --
 
-function mod:VitalityTransfer(args)
-	vitalityTransferCount = vitalityTransferCount + 1
-	if vitalityTransferCount == 3 then
-		stage = 2
-		self:Message2("stages", "cyan", CL.soon:format(self:SpellName(-17773)), false) -- Lady Waycrest
-		self:PlaySound("stages", "info")
+do
+	local function warnLadyWacrest()
+		mod:Message2("stages", "cyan", mod:SpellName(-17773), false)
+		mod:PlaySound("stages", "long")
+	end
+
+	function mod:VitalityTransfer(args)
+		vitalityTransferCount = vitalityTransferCount + 1
+		if vitalityTransferCount == 3 then
+			stage = 2
+			self:Message2("stages", "cyan", CL.soon:format(self:SpellName(-17773)), false) -- Lady Waycrest
+			self:PlaySound("stages", "info")
+			self:Bar("stages", 6, CL.incoming:format(self:SpellName(-17773)), false)
+			self:SimpleTimer(warnLadyWacrest, 6)
+		end
 	end
 end
 
@@ -130,9 +139,4 @@ end
 function mod:PutridVitality(args)
 	self:StackMessage(args.spellId, args.destName, args.amount, "cyan")
 	self:PlaySound(args.spellId, "info")
-end
-
-function mod:SoulArmorRemoved(args)
-	self:Message2("stages", "cyan", self:SpellName(-17773), false) -- Lady Waycrest
-	self:PlaySound("stages", "long")
 end

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -72,8 +72,8 @@ do
 			stage = 2
 			self:Message2("stages", "cyan", CL.soon:format(self:SpellName(-17773)), false) -- Lady Waycrest
 			self:PlaySound("stages", "info")
-			self:Bar("stages", 6, CL.incoming:format(self:SpellName(-17773)), "achievement_character_undead_female")
-			self:SimpleTimer(warnLadyWacrest, 6)
+			self:Bar("stages", 7.5, CL.incoming:format(self:SpellName(-17773)), "achievement_character_undead_female")
+			self:SimpleTimer(warnLadyWacrest, 7.5)
 		end
 	end
 end

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Lord and Lady Waycrest", 1862, 2128)
 if not mod then return end
 mod:RegisterEnableMob(131545, 131527) -- Lady Waycrest, Lord Waycrest
 mod.engageId = 2116
+mod.respawnTime = 20
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/BfA/WaycrestManor/Waycrest.lua
+++ b/BfA/WaycrestManor/Waycrest.lua
@@ -59,10 +59,8 @@ function mod:WastingStrike(args)
 end
 
 do
-	local playerList, isOnMe = {}, false
+	local playerList, isOnMe, proxList = mod:NewTargetList(), false, {}
 	function mod:VirulentPathogen(args)
-		self:TargetMessage2(args.spellId, "red", args.destName)
-		self:PlaySound(args.spellId, "warning", nil, args.destName)
 		self:Bar(args.spellId, 15.5)
 	end
 
@@ -72,8 +70,13 @@ do
 			self:Say(args.spellId)
 			self:SayCountdown(args.spellId, 5)
 		end
+
 		playerList[#playerList+1] = args.destName
-		self:OpenProximity(args.spellId, 5, not isOnMe and playerList)
+		self:TargetsMessage(args.spellId, "red", playerList, 5)
+		self:PlaySound(args.spellId, "warning", nil, playerList)
+
+		proxList[#proxList+1] = args.destName
+		self:OpenProximity(args.spellId, 5, not isOnMe and proxList)
 	end
 
 	function mod:VirulentPathogenRemoved(args)
@@ -81,11 +84,11 @@ do
 			isOnMe = false
 			self:CancelSayCountdown(args.spellId)
 		end
-		tDeleteItem(playerList, args.destName)
-		if #playerList == 0 then
+		tDeleteItem(proxList, args.destName)
+		if #proxList == 0 then
 			self:CloseProximity(args.spellId)
 		else
-			self:OpenProximity(args.spellId, 5, not isOnMe and playerList)
+			self:OpenProximity(args.spellId, 5, not isOnMe and proxList)
 		end
 	end
 end


### PR DESCRIPTION
Heartsbane:
- Add respawn time

Raal:
- Add respawn time
- Add stack count to Consumed Servant message

Waycrest:
- Add respawn time
- Add Virulent Pathogen targetsmessage and proximity
- Move warning for Discordant Cadenza to the end of the cast
- Add Wracking Chord timer
- Add message and timer when Lady Waycrest is going to become active

GorakTul:
- Add respawn time
- Add warning when an add is killed
- Only show Darkened Lightning message for interrupters
- Improve timers
- Add Death Lens target message

Trash:
- Add Effigy Reconstruction
- Throttle Dinner Bell, Retch, Shrapnel Trap, Severing Serpent, and Infected Thorn