### PR TITLE
BfA/SiegeOfBoralus: Add Demolishing Terror count and more trash abilities

### DIFF
--- a/BfA/SiegeOfBoralus/Brainbridge.lua
+++ b/BfA/SiegeOfBoralus/Brainbridge.lua
@@ -8,6 +8,7 @@ local mod, CL = BigWigs:NewBoss("Sergeant Bainbridge", 1822, 2133)
 if not mod then return end
 mod:RegisterEnableMob(128649) -- Sergeant Bainbridge
 mod.engageId = 2097
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Eisenfluträuber"
 	L.vanguard = "Vorhut von Kul Tiras"
 	L.marksman = "Schütze von Kul Tiras"
+	L.buccaneer = "Bukanier der Bilgeratten"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/deDE.lua
+++ b/BfA/SiegeOfBoralus/Locales/deDE.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Vorhut von Kul Tiras"
 	L.marksman = "Schütze von Kul Tiras"
 	L.buccaneer = "Bukanier der Bilgeratten"
+	L.invader = "Aschenwindeindringling"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "deDE")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Vanguardia de Kul Tiras"
 	L.marksman = "Tirador de Kul Tiras"
 	L.buccaneer = "Bucanero de las Ratas de Pantoque"
+	L.invader = "Invasor de los Gobernalle"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/esES.lua
+++ b/BfA/SiegeOfBoralus/Locales/esES.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Asaltante Marea de Hierro"
 	L.vanguard = "Vanguardia de Kul Tiras"
 	L.marksman = "Tirador de Kul Tiras"
+	L.buccaneer = "Bucanero de las Ratas de Pantoque"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "esES") or BigWigs:NewBossLocale("Sergeant Bainbridge", "esMX")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Ecumeur des Lamineurs"
 	L.vanguard = "Avant-garde de Kul Tiras"
 	L.marksman = "Tireur d'élite de Kul Tiras"
+	L.buccaneer = "Boucanier des Soutaillons"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/frFR.lua
+++ b/BfA/SiegeOfBoralus/Locales/frFR.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Avant-garde de Kul Tiras"
 	L.marksman = "Tireur d'élite de Kul Tiras"
 	L.buccaneer = "Boucanier des Soutaillons"
+	L.invader = "Envahisseur corsandre"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "frFR")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Avanguardia di Kul Tiras"
 	L.marksman = "Tiratore di Kul Tiras"
 	L.buccaneer = "Bucaniere dei Ratti di Sentina"
+	L.invader = "Invasore dei Bracescura"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/itIT.lua
+++ b/BfA/SiegeOfBoralus/Locales/itIT.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Incursore Marferreo"
 	L.vanguard = "Avanguardia di Kul Tiras"
 	L.marksman = "Tiratore di Kul Tiras"
+	L.buccaneer = "Bucaniere dei Ratti di Sentina"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "itIT")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "쿨 티란 선봉대원"
 	L.marksman = "쿨 티란 명사수"
 	L.buccaneer = "항만의 시궁쥐단 해적단원"
+	L.invader = "애쉬베인 침략자"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/koKR.lua
+++ b/BfA/SiegeOfBoralus/Locales/koKR.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "무쇠파도 약탈단"
 	L.vanguard = "쿨 티란 선봉대원"
 	L.marksman = "쿨 티란 명사수"
+	L.buccaneer = "항만의 시궁쥐단 해적단원"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "koKR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Saqueador Maré-férrea"
 	L.vanguard = "Vanguarda Kultirena"
 	L.marksman = "Atirador Perito Kultireno"
+	L.buccaneer = "Bucaneiro Rato de Porão"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ptBR.lua
+++ b/BfA/SiegeOfBoralus/Locales/ptBR.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Vanguarda Kultirena"
 	L.marksman = "Atirador Perito Kultireno"
 	L.buccaneer = "Bucaneiro Rato de Porão"
+	L.invader = "Invasor Grimpagris"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ptBR")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "Налетчик из братства Стальных Волн"
 	L.vanguard = "Кул-тирасский боец авангарда"
 	L.marksman = "Кул-тирасский стрелок"
+	L.buccaneer = "Буканьер из братства Трюмных Крыс"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/ruRU.lua
+++ b/BfA/SiegeOfBoralus/Locales/ruRU.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "Кул-тирасский боец авангарда"
 	L.marksman = "Кул-тирасский стрелок"
 	L.buccaneer = "Буканьер из братства Трюмных Крыс"
+	L.invader = "Захватчик дома Эшвейнов"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "ruRU")

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "库尔提拉斯先锋"
 	L.marksman = "库尔提拉斯神射手"
 	L.buccaneer = "水鼠帮海盗"
+	L.invader = "艾什凡入侵者"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhCN.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhCN.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "铁潮袭击者"
 	L.vanguard = "库尔提拉斯先锋"
 	L.marksman = "库尔提拉斯神射手"
+	L.buccaneer = "水鼠帮海盗"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhCN")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -12,6 +12,7 @@ if L then
 	L.raider = "鐵潮劫掠者"
 	L.vanguard = "庫爾提拉斯先鋒"
 	L.marksman = "庫爾提拉斯神射手"
+	-- L.buccaneer = "Bilge Rat Buccaneer"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -12,8 +12,8 @@ if L then
 	L.raider = "鐵潮劫掠者"
 	L.vanguard = "庫爾提拉斯先鋒"
 	L.marksman = "庫爾提拉斯神射手"
-	-- L.buccaneer = "Bilge Rat Buccaneer"
-	-- L.invader = "Ashvane Invader"
+	--L.buccaneer = "Bilge Rat Buccaneer"
+	--L.invader = "Ashvane Invader"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")

--- a/BfA/SiegeOfBoralus/Locales/zhTW.lua
+++ b/BfA/SiegeOfBoralus/Locales/zhTW.lua
@@ -13,6 +13,7 @@ if L then
 	L.vanguard = "庫爾提拉斯先鋒"
 	L.marksman = "庫爾提拉斯神射手"
 	-- L.buccaneer = "Bilge Rat Buccaneer"
+	-- L.invader = "Ashvane Invader"
 end
 
 L = BigWigs:NewBossLocale("Sergeant Bainbridge", "zhTW")

--- a/BfA/SiegeOfBoralus/Options/Colors.lua
+++ b/BfA/SiegeOfBoralus/Options/Colors.lua
@@ -54,9 +54,11 @@ BigWigs:AddColors("Siege of Boralus Trash", {
 	[257641] = "blue",
 	[268260] = "orange",
 	[272421] = {"blue","yellow"},
+	[272546] = "orange",
 	[272711] = "orange",
 	[272827] = "orange",
 	[272874] = "orange",
 	[274569] = "orange",
 	[275826] = {"orange","red"},
+	[275835] = "red",
 })

--- a/BfA/SiegeOfBoralus/Options/Sounds.lua
+++ b/BfA/SiegeOfBoralus/Options/Sounds.lua
@@ -54,9 +54,11 @@ BigWigs:AddSounds("Siege of Boralus Trash", {
 	[257641] = "info",
 	[268260] = "alarm",
 	[272421] = "info",
+	[272546] = "alert",
 	[272711] = "alert",
 	[272827] = "alert",
 	[272874] = "info",
 	[274569] = "alert",
 	[275826] = {"alarm","info"},
+	[275835] = "alert",
 })

--- a/BfA/SiegeOfBoralus/Redhook.lua
+++ b/BfA/SiegeOfBoralus/Redhook.lua
@@ -8,6 +8,7 @@ local mod, CL = BigWigs:NewBoss("Chopper Redhook", 1822, 2132)
 if not mod then return end
 mod:RegisterEnableMob(128650) -- Chopper Redhook
 mod.engageId = 2098
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -18,7 +18,8 @@ mod:RegisterEnableMob(
 	141284, -- Kul Tiran Wavetender
 	141283, -- Kul Tiran Halberd
 	138019, -- Kul Tiran Vanguard
-	141285  -- Kul Tiran Marksman
+	141285, -- Kul Tiran Marksman
+	129366  -- Bilge Rat Buccaneer
 )
 
 --------------------------------------------------------------------------------
@@ -38,6 +39,7 @@ if L then
 	L.raider = "Irontide Raider"
 	L.vanguard = "Kul Tiran Vanguard"
 	L.marksman = "Kul Tiran Marksman"
+	L.buccaneer = "Bilge Rat Buccaneer"
 end
 
 --------------------------------------------------------------------------------
@@ -60,6 +62,8 @@ function mod:GetOptions()
 		272827, -- Viscous Slobber
 		-- Bilge Rat Tempest
 		274569, -- Revitalizing Mist
+		-- Bilge Rat Buccaneer
+		272546, -- Banana Rampage
 		-- Irontide Raider
 		257170, -- Savage Tempest
 		-- Kul Tiran Wavetender
@@ -77,6 +81,7 @@ function mod:GetOptions()
 		[257169] = L.demolisher,
 		[272827] = L.pillager,
 		[274569] = L.tempest,
+		[272546] = L.buccaneer,
 		[257170] = L.raider,
 		[256957] = L.wavetender,
 		[256627] = L.halberd,
@@ -99,6 +104,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "ViscousSlobber", 272827)
 	-- Bilge Rat Tempest
 	self:Log("SPELL_CAST_START", "RevitalizingMist", 274569)
+	-- Bilge Rat Buccaneer
+	self:Log("SPELL_CAST_START", "BananaRampage", 272546)
 	-- Irontide Raider
 	self:Log("SPELL_CAST_START", "SavageTempest", 257170)
 	self:Log("SPELL_CAST_SUCCESS", "SavageTempestSuccess", 257170)
@@ -152,6 +159,11 @@ function mod:ViscousSlobber(args)
 end
 
 function mod:RevitalizingMist(args)
+	self:Message2(args.spellId, "orange")
+	self:PlaySound(args.spellId, "alert")
+end
+
+function mod:BananaRampage(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alert")
 end

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -102,6 +102,7 @@ function mod:OnBossEnable()
 	-- Irontide Raider
 	self:Log("SPELL_CAST_START", "SavageTempest", 257170)
 	self:Log("SPELL_CAST_SUCCESS", "SavageTempestSuccess", 257170)
+	self:Death("IrontideRaiderDeath", 129369)
 	-- Kul Tiran Wavetender
 	self:Log("SPELL_CAST_START", "WatertightShell", 256957)
 	self:Log("SPELL_AURA_APPLIED", "WatertightShellApplied", 256957)
@@ -162,6 +163,10 @@ end
 
 function mod:SavageTempestSuccess(args)
 	self:CDBar(args.spellId, 14)
+end
+
+function mod:IrontideRaiderDeath(args)
+	self:StopBar(257170) -- Savage Tempest
 end
 
 function mod:WatertightShell(args)

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -161,7 +161,7 @@ function mod:SavageTempest(args)
 end
 
 function mod:SavageTempestSuccess(args)
-	self:CDBar(257170, 14) -- Savage Tempest
+	self:CDBar(args.spellId, 14)
 end
 
 function mod:WatertightShell(args)

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -153,6 +153,7 @@ do
 	function mod:StingingVenomCoating(args)
 		local t = args.time
 		if t-prev > 1.5 then
+			prev = t
 			self:Message2(args.spellId, "red")
 			self:PlaySound(args.spellId, "alert")
 		end

--- a/BfA/SiegeOfBoralus/Trash.lua
+++ b/BfA/SiegeOfBoralus/Trash.lua
@@ -19,7 +19,8 @@ mod:RegisterEnableMob(
 	141283, -- Kul Tiran Halberd
 	138019, -- Kul Tiran Vanguard
 	141285, -- Kul Tiran Marksman
-	129366  -- Bilge Rat Buccaneer
+	129366, -- Bilge Rat Buccaneer
+	137516  -- Ashvane Invader
 )
 
 --------------------------------------------------------------------------------
@@ -40,6 +41,7 @@ if L then
 	L.vanguard = "Kul Tiran Vanguard"
 	L.marksman = "Kul Tiran Marksman"
 	L.buccaneer = "Bilge Rat Buccaneer"
+	L.invader = "Ashvane Invader"
 end
 
 --------------------------------------------------------------------------------
@@ -53,6 +55,8 @@ function mod:GetOptions()
 		-- Ashvane Commander
 		272874, -- Trample
 		275826, -- Bolstering Shout
+		-- Ashvane Invader
+		275835, -- Stinging Venom Coating
 		-- Ashvane Spotter
 		272421, -- Sighted Artillery
 		-- Bilge Rat Demolisher
@@ -77,6 +81,7 @@ function mod:GetOptions()
 	}, {
 		[268260] = L.cannoneer,
 		[272874] = L.commander,
+		[275835] = L.invader,
 		[272421] = L.spotter,
 		[257169] = L.demolisher,
 		[272827] = L.pillager,
@@ -96,6 +101,8 @@ function mod:OnBossEnable()
 	-- Ashvane Commander
 	self:Log("SPELL_CAST_START", "BolsteringShout", 275826)
 	self:Log("SPELL_CAST_SUCCESS", "BolsteringShoutSuccess", 275826)
+	-- Ashvane Invader
+	self:Log("SPELL_CAST_START", "StingingVenomCoating", 275835)
 	-- Ashvane Spotter
 	self:Log("SPELL_AURA_APPLIED", "SightedArtillery", 272421)
 	-- Bilge Rat Demolisher
@@ -139,6 +146,17 @@ end
 function mod:BolsteringShoutSuccess(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
+end
+
+do
+	local prev = 0
+	function mod:StingingVenomCoating(args)
+		local t = args.time
+		if t-prev > 1.5 then
+			self:Message2(args.spellId, "red")
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
 end
 
 function mod:SightedArtillery(args)

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -72,7 +72,7 @@ function mod:OnEngage()
 	playersWithPutridWaters = {}
 	self:CDBar(275014, 5) -- Putrid Waters
 	self:CDBar(270185, 6) -- Call of the Deep
-	self:Bar("demolishing", 20, CL.count:format(L.demolishing, 2), L.demolishing_icon) -- Summon Demolisher
+	self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), 2), L.demolishing_icon) -- Summon Demolisher
 end
 
 function mod:OnBossDisable()

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Viq'Goth", 1822, 2140)
 if not mod then return end
 mod:RegisterEnableMob(128652) -- Viq'Goth
 mod.engageId = 2100
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Locals

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -103,7 +103,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		self:Message2("demolishing", "yellow", CL.count:format(CL.spawned:format(self:SpellName(L.demolishing)), demolisherCount), L.demolishing_icon)
 		self:PlaySound("demolishing", "alert")
 		if demolisherCount <= 4 then -- XXX check this
-			self:Bar("demolishing", 20, CL.count:format(L.demolishing, demolisherCount+1), L.demolishing_icon)
+			self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), demolisherCount+1), L.demolishing_icon)
 		end
 	end
 end
@@ -111,7 +111,7 @@ end
 function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
 	if not engagedGripping and self:GetBossId(137405) then -- Check if Gripping Terror is up
 		engagedGripping = true
-		self:Bar("demolishing", 20, CL.count:format(L.demolishing, 1), L.demolishing_icon) -- Summon Demolisher
+		self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), 1), L.demolishing_icon) -- Summon Demolisher
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -72,7 +72,7 @@ function mod:OnEngage()
 	playersWithPutridWaters = {}
 	self:CDBar(275014, 5) -- Putrid Waters
 	self:CDBar(270185, 6) -- Call of the Deep
-	self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
+	self:Bar("demolishing", 20, CL.count:format(L.demolishing, 2), L.demolishing_icon) -- Summon Demolisher
 end
 
 function mod:OnBossDisable()
@@ -100,9 +100,11 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		end
 	elseif spellId == 270605 then -- Summon Demolisher
 		demolisherCount = demolisherCount + 1
-		self:Message2("demolishing", "yellow", CL.count:format(CL.spawned:format(self:SpellName(L.demolishing)), demolisherCount), L.demolishing_icon)
-		self:PlaySound("demolishing", "alert")
-		if demolisherCount <= 4 then -- XXX check this
+		if demolisherCount <= 5 then -- Demolishers stop spawning after the fifth, but the spell is still cast
+			self:Message2("demolishing", "yellow", CL.count:format(CL.spawned:format(self:SpellName(L.demolishing)), demolisherCount), L.demolishing_icon)
+			self:PlaySound("demolishing", "alert")
+		end
+		if demolisherCount <= 4 then
 			self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), demolisherCount+1), L.demolishing_icon)
 		end
 	end
@@ -111,7 +113,7 @@ end
 function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
 	if not engagedGripping and self:GetBossId(137405) then -- Check if Gripping Terror is up
 		engagedGripping = true
-		self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), 1), L.demolishing_icon) -- Summon Demolisher
+		self:Bar("demolishing", 20, CL.count:format(self:SpellName(L.demolishing), 2), L.demolishing_icon) -- Summon Demolisher
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -16,6 +16,7 @@ local stage = 1
 local markCount = 1
 local playersWithPutridWaters = {}
 local engagedGripping = true
+local demolisherCount = 1
 
 --------------------------------------------------------------------------------
 -- Localization
@@ -66,6 +67,7 @@ function mod:OnEngage()
 	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 	stage = 1
 	markCount = 1
+	demolisherCount = 1
 	engagedGripping = true
 	playersWithPutridWaters = {}
 	self:CDBar(275014, 5) -- Putrid Waters
@@ -92,13 +94,17 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		stage = stage + 1
 		if stage < 4 then
 			engagedGripping = false
+			demolisherCount = 1
 			self:Message2("stages", "green", CL.stage:format(stage), false)
 			self:PlaySound("stages", "long")
 		end
 	elseif spellId == 270605 then -- Summon Demolisher
-		self:Message2("demolishing", "yellow", CL.spawned:format(self:SpellName(L.demolishing)), L.demolishing_icon)
+		demolisherCount = demolisherCount + 1
+		self:Message2("demolishing", "yellow", CL.count:format(CL.spawned:format(self:SpellName(L.demolishing)), demolisherCount), L.demolishing_icon)
 		self:PlaySound("demolishing", "alert")
-		self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon)
+		if demolisherCount <= 4 then -- XXX check this
+			self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon)
+		end
 	end
 end
 

--- a/BfA/SiegeOfBoralus/Viqgoth.lua
+++ b/BfA/SiegeOfBoralus/Viqgoth.lua
@@ -103,7 +103,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		self:Message2("demolishing", "yellow", CL.count:format(CL.spawned:format(self:SpellName(L.demolishing)), demolisherCount), L.demolishing_icon)
 		self:PlaySound("demolishing", "alert")
 		if demolisherCount <= 4 then -- XXX check this
-			self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon)
+			self:Bar("demolishing", 20, CL.count:format(L.demolishing, demolisherCount+1), L.demolishing_icon)
 		end
 	end
 end
@@ -111,7 +111,7 @@ end
 function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
 	if not engagedGripping and self:GetBossId(137405) then -- Check if Gripping Terror is up
 		engagedGripping = true
-		self:Bar("demolishing", 20, L.demolishing, L.demolishing_icon) -- Summon Demolisher
+		self:Bar("demolishing", 20, CL.count:format(L.demolishing, 1), L.demolishing_icon) -- Summon Demolisher
 	end
 end
 


### PR DESCRIPTION
Brainbridge/Redhook:
- Add respawn time

Viqgoth:
- Add respawn time
- Add Demolishing Terror count
- Stop Demolishing Terror bars and messages after 5. They stop spawning but the spawn spell is still cast.

Trash:
- Stop Savage Tempest bar on death
- Add Banana Rampage
- Add Stinging Venom Coating