### PR TITLE
BfA/ShrineOfTheStorm/Council: Add Blessing of the Tempest

### DIFF
--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -93,11 +93,11 @@ do
 		self:Message2(args.spellId, "yellow", CL.onboss:format(args.spellName))
 		self:PlaySound(args.spellId, "info")
 		self:TargetBar(args.spellId, 11, args.destName)
+		self:CDBar(args.spellId, 25)
 	end
 
 	function mod:BlessingoftheTempestRemoved(args)
 		blessingActive = false
-		self:StopBar(args.spellId, args.destName)
 	end
 
 	function mod:Interrupted(args)

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -16,6 +16,7 @@ function mod:GetOptions()
 	return {
 		267891, -- Swiftness Ward
 		267818, -- Slicing Blast
+		267830, -- Blessing of the Tempest
 		267905, -- Reinforcing Ward
 		{267899, "TANK"}, -- Hindering Cleave
 		{267901, "TANK"}, -- Blessing of Ironsides
@@ -33,6 +34,9 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "BlessingofIronsides", 267901)
 	self:Log("SPELL_AURA_APPLIED", "BlessingofIronsidesApplied", 267901)
 	self:Log("SPELL_CAST_START", "HinderingCleave", 267899)
+	self:Log("SPELL_AURA_APPLIED", "BlessingoftheTempestApplied", 267830)
+	self:Log("SPELL_AURA_REMOVED", "BlessingoftheTempestRemoved", 267830)
+	self:Log("SPELL_INTERRUPT", "Interupted", "*")
 end
 
 function mod:OnEngage()
@@ -79,6 +83,33 @@ end
 
 function mod:BlessingofIronsidesApplied(args)
 	self:TargetBar(args.spellId, 8, args.destName)
+end
+
+do
+	local blessingActive = false
+
+	function mod:BlessingoftheTempestApplied(args)
+		blessingActive = true
+		self:Message2(args.spellId, "yellow", CL.onboss:format(args.spellName))
+		self:PlaySound(args.spellId, "info")
+		self:TargetBar(args.spellId, 11, args.destName)
+	end
+
+	function mod:BlessingoftheTempestRemoved(args)
+		blessingActive = false
+		self:StopBar(args.spellId, args.destName)
+	end
+
+	function mod:Interrupted(args)
+		if blessingActive and self:MobId(args.destGUID) == 134058 then -- Galecaller Faye
+			local bossId = self:GetBossId(args.destGUID)
+			-- Tempest spawns close to the boss, so warnings aren't needed for ranged
+			if IsItemInRange(63427, bossId) then --Worgsaw, 8yd
+				self:Message2(args.spellId, "yellow", self:SpellName(274437), 274437) -- Tempest
+				self:PlaySound(args.spellId, "info")
+			end
+		end
+	end
 end
 
 function mod:HinderingCleave(args)

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -68,8 +68,8 @@ function mod:SwiftnessWardApplied(args)
 end
 
 function mod:SlicingBlast(args)
-	self:Message2(args.spellId, "yellow")
-	if self:Interrupter(args.sourceGUID) then
+	self:Message2(args.spellId, "orange")
+	if self:Interrupter() then
 		self:PlaySound(args.spellId, "alert")
 	end
 end
@@ -118,8 +118,8 @@ do
 end
 
 function mod:HinderingCleave(args)
-	self:Message2(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
+	self:Message2(args.spellId, "red")
+	self:PlaySound(args.spellId, "alarm")
 	self:Bar(args.spellId, 17)
 end
 

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -43,9 +43,11 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:Bar(267899, 6) -- Hindering Cleave
-	self:Bar(267891, 14.5) -- Swiftness Ward
+	self:Bar(267899, 8.5) -- Hindering Cleave
+	self:Bar(267891, 17) -- Swiftness Ward
 	self:Bar(267905, 30) -- Reinforcing Ward
+	self:Bar(267901, 6.1) -- Blessing of Ironsides
+	self:Bar(267830, 26.7) -- Blessing of the Tempest
 end
 
 --------------------------------------------------------------------------------
@@ -75,7 +77,7 @@ end
 function mod:ReinforcingWard(args)
 	self:Message2(args.spellId, "cyan")
 	self:PlaySound(args.spellId, "long")
-	self:Bar(args.spellId, 30)
+	self:Bar(args.spellId, 32)
 end
 
 function mod:BlessingofIronsides(args)
@@ -96,7 +98,7 @@ do
 		self:Message2(args.spellId, "yellow", CL.onboss:format(args.spellName))
 		self:PlaySound(args.spellId, "info")
 		self:TargetBar(args.spellId, 11, args.destName)
-		self:CDBar(args.spellId, 25)
+		self:CDBar(args.spellId, 20)
 	end
 
 	function mod:BlessingoftheTempestRemoved(args)

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -57,7 +57,7 @@ end
 
 function mod:SwiftnessWardApplied(args)
 	if self:Me(args.destGUID) then
-		self:Message2(267891, "green")
+		self:PersonalMessage(267891)
 		self:PlaySound(267891, "info")
 	end
 end

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -110,7 +110,7 @@ do
 		if blessingActive and self:MobId(args.destGUID) == 134058 then -- Galecaller Faye
 			local bossId = self:GetBossId(args.destGUID)
 			-- Tempest spawns close to the boss, so warnings aren't needed for ranged
-			if IsItemInRange(63427, bossId) then --Worgsaw, 8yd
+			if IsItemInRange(63427, bossId) then -- Worgsaw, 8yd
 				self:Message2(267830, "yellow", self:SpellName(274437), 274437) -- Tempest
 				self:PlaySound(267830, "info")
 			end

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -36,7 +36,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "HinderingCleave", 267899)
 	self:Log("SPELL_AURA_APPLIED", "BlessingoftheTempestApplied", 267830)
 	self:Log("SPELL_AURA_REMOVED", "BlessingoftheTempestRemoved", 267830)
-	self:Log("SPELL_INTERRUPT", "Interupted", "*")
+	self:Log("SPELL_INTERRUPT", "Interrupted", "*")
 end
 
 function mod:OnEngage()

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -7,7 +7,6 @@ local mod, CL = BigWigs:NewBoss("Tidesage Coucil", 1864, 2154)
 if not mod then return end
 mod:RegisterEnableMob(134058, 134063) -- Galecaller Faye, Brother Ironhull
 mod.engageId = 2131
-mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -105,8 +105,8 @@ do
 			local bossId = self:GetBossId(args.destGUID)
 			-- Tempest spawns close to the boss, so warnings aren't needed for ranged
 			if IsItemInRange(63427, bossId) then --Worgsaw, 8yd
-				self:Message2(args.spellId, "yellow", self:SpellName(274437), 274437) -- Tempest
-				self:PlaySound(args.spellId, "info")
+				self:Message2(267830, "yellow", self:SpellName(274437), 274437) -- Tempest
+				self:PlaySound(267830, "info")
 			end
 		end
 	end

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -37,6 +37,9 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "BlessingoftheTempestApplied", 267830)
 	self:Log("SPELL_AURA_REMOVED", "BlessingoftheTempestRemoved", 267830)
 	self:Log("SPELL_INTERRUPT", "Interrupted", "*")
+
+	self:Death("FayeDeath", 134058)
+	self:Death("IronhullDeath", 134063)
 end
 
 function mod:OnEngage()
@@ -116,4 +119,15 @@ function mod:HinderingCleave(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "alert")
 	self:Bar(args.spellId, 17)
+end
+
+function mod:FayeDeath(args)
+	self:StopBar(267830) -- Blessing of the Tempest
+	self:StopBar(267891) -- Swiftness Ward
+end
+
+function mod:IronhullDeath(args)
+	self:StopBar(267899) -- Hindering Cleave
+	self:StopBar(267905) -- Reinforcing Ward
+	self:StopBar(267901) -- Blessing of Ironsides
 end

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -96,7 +96,7 @@ do
 
 	function mod:BlessingoftheTempestApplied(args)
 		blessingActive = true
-		self:Message2(args.spellId, "yellow", CL.onboss:format(args.spellName))
+		self:Message2(args.spellId, "yellow")
 		self:PlaySound(args.spellId, "info")
 		self:TargetBar(args.spellId, 11, args.destName)
 		self:CDBar(args.spellId, 20)

--- a/BfA/ShrineOfTheStorm/Council.lua
+++ b/BfA/ShrineOfTheStorm/Council.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Tidesage Coucil", 1864, 2154)
 if not mod then return end
 mod:RegisterEnableMob(134058, 134063) -- Galecaller Faye, Brother Ironhull
 mod.engageId = 2131
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/BfA/ShrineOfTheStorm/Options/Colors.lua
+++ b/BfA/ShrineOfTheStorm/Options/Colors.lua
@@ -10,7 +10,8 @@ BigWigs:AddColors("Aqu'sirr", {
 
 BigWigs:AddColors("Tidesage Coucil", {
 	[267818] = "yellow",
-	[267891] = {"cyan","green"},
+	[267830] = "yellow",
+	[267891] = {"blue","cyan"},
 	[267899] = "yellow",
 	[267901] = "red",
 	[267905] = "cyan",

--- a/BfA/ShrineOfTheStorm/Options/Colors.lua
+++ b/BfA/ShrineOfTheStorm/Options/Colors.lua
@@ -9,10 +9,10 @@ BigWigs:AddColors("Aqu'sirr", {
 })
 
 BigWigs:AddColors("Tidesage Coucil", {
-	[267818] = "yellow",
+	[267818] = "orange",
 	[267830] = "yellow",
 	[267891] = {"blue","cyan"},
-	[267899] = "yellow",
+	[267899] = "red",
 	[267901] = "red",
 	[267905] = "cyan",
 })

--- a/BfA/ShrineOfTheStorm/Options/Sounds.lua
+++ b/BfA/ShrineOfTheStorm/Options/Sounds.lua
@@ -10,6 +10,7 @@ BigWigs:AddSounds("Aqu'sirr", {
 
 BigWigs:AddSounds("Tidesage Coucil", {
 	[267818] = "alert",
+	[267830] = "info",
 	[267891] = {"info","long"},
 	[267899] = "alert",
 	[267901] = "warning",

--- a/BfA/ShrineOfTheStorm/Options/Sounds.lua
+++ b/BfA/ShrineOfTheStorm/Options/Sounds.lua
@@ -12,7 +12,7 @@ BigWigs:AddSounds("Tidesage Coucil", {
 	[267818] = "alert",
 	[267830] = "info",
 	[267891] = {"info","long"},
-	[267899] = "alert",
+	[267899] = "alarm",
 	[267901] = "warning",
 	[267905] = "long",
 })

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -7,6 +7,7 @@ local mod, CL = BigWigs:NewBoss("Lord Stormsong", 1864, 2155)
 if not mod then return end
 mod:RegisterEnableMob(134060)
 mod.engageId = 2132
+mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Localization

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -7,7 +7,6 @@ local mod, CL = BigWigs:NewBoss("Lord Stormsong", 1864, 2155)
 if not mod then return end
 mod:RegisterEnableMob(134060)
 mod.engageId = 2132
-mod.respawnTime = 30
 
 --------------------------------------------------------------------------------
 -- Localization


### PR DESCRIPTION
closes #344 

The Blessing of the Tempest warning only displays for players near the boss, so ranged won't get warnings about dodging tornadoes in melee.

Council:
- Add Blessing of the Tempest
- Improve timers
- Add respawn time
- Adjust colors since almost everything was yellow

Stormsong:
- Add respawn time