### PR TITLE
BfA/Mechagon: Fix timers and add hard mode timers

### DIFF
--- a/BfA/Mechagon/KUJ0.lua
+++ b/BfA/Mechagon/KUJ0.lua
@@ -30,6 +30,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "VentingFlames", 291946)
 	self:Log("SPELL_CAST_START", "ExplosiveLeap", 291973)
 	self:Log("SPELL_AURA_APPLIED", "ExplosiveLeapApplied", 291972)
+	self:Log("SPELL_AURA_REMOVED", "ExplosiveLeapRemoved", 291972)
 	self:Log("SPELL_AURA_APPLIED", "BlazingChompApplied", 294929)
 end
 

--- a/BfA/Mechagon/KUJ0.lua
+++ b/BfA/Mechagon/KUJ0.lua
@@ -1,6 +1,5 @@
 --------------------------------------------------------------------------------
 -- TODO
--- Proximity for Explosive Leap (debuff is 291972)
 -- Air Drop timers pull:7.3, 28.3, 28.7, 15.8, 19.7, 30.3, 27.8, 15.8
 --
 
@@ -21,7 +20,7 @@ function mod:GetOptions()
 	return {
 		291918, -- Air Drop
 		291946, -- Venting Flames
-		291973, -- Explosive Leap
+		{291973, "PROXIMITY", "SAY"}, -- Explosive Leap
 		{294929, "TANK_HEALER"}, -- Blazing Chomp
 	}
 end
@@ -30,13 +29,14 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "AirDrop", 291918)
 	self:Log("SPELL_CAST_START", "VentingFlames", 291946)
 	self:Log("SPELL_CAST_START", "ExplosiveLeap", 291973)
+	self:Log("SPELL_AURA_APPLIED", "ExplosiveLeapApplied", 291972)
 	self:Log("SPELL_AURA_APPLIED", "BlazingChompApplied", 294929)
 end
 
 function mod:OnEngage()
-	self:Bar(291918, 7.3) -- Air Drop
-	self:Bar(291946, 18.3) -- Venting Flames
-	self:Bar(291973, 30.4) -- Explosive Leap
+	self:Bar(291918, 8.1) -- Air Drop
+	self:Bar(291946, 18) -- Venting Flames
+	self:Bar(291973, 30.2) -- Explosive Leap
 end
 
 --------------------------------------------------------------------------------
@@ -46,6 +46,7 @@ end
 function mod:AirDrop(args)
 	self:Message2(args.spellId, "yellow")
 	self:PlaySound(args.spellId, "info")
+	self:CDBar(args.spellId, 27) -- Between 27 and 33
 end
 
 function mod:VentingFlames(args)
@@ -59,6 +60,29 @@ function mod:ExplosiveLeap(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alert")
 	self:CDBar(args.spellId, 30.4)
+end
+
+do
+	local isOnMe = false
+	local proxList = {}
+	function mod:ExplosiveLeapApplied(args)
+		if self:Me(args.destGUID) then
+			isOnMe = true
+			self:Say(291973)
+		end
+		proxList[#proxList+1] = args.destName
+		self:OpenProximity(291973, 10, not isOnMe and proxList)
+	end
+
+	function mod:ExplosiveLeapRemoved(args)
+		tDeleteItem(proxList, args.destName)
+		if self:Me(args.destGUID) then
+			isOnMe = false
+		end
+		if #proxList == 0 then
+			self:CloseProximity(291973)
+		end
+	end
 end
 
 function mod:BlazingChompApplied(args)

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -37,7 +37,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "GigaZap", 291928, 292264) -- Stage 1, stage 2
 	self:Log("SPELL_CAST_START", "TakeOff", 291613)
 	self:Log("SPELL_CAST_SUCCESS", "CuttingBeam", 291626)
-	self:Log("SPELL_CAST_SUCCESS", "MagnetoArm", 283551)
+	self:Log("SPELL_CAST_SUCCESS", "MagnetoArm", 283551) -- Boss' cast activating the device
+	self:Log("SPELL_CAST_SUCCESS", "MagnetoArmSuccess", 283143) -- Pull in effect start
 	self:Log("SPELL_CAST_START", "ProtocolNinetyNine", 292290)
 
 	self:Death("AerialUnitDeath", 150396)
@@ -49,7 +50,7 @@ function mod:OnEngage()
 	gigaZapCount = 0
 	self:Bar(291865, 5.9) -- Recalibrate
 	self:Bar(291928, 8.4) -- Giga-Zap
-	self:Bar(291613, 31.4) -- Take Off
+	self:Bar(291613, 30) -- Take Off
 end
 
 --------------------------------------------------------------------------------
@@ -58,8 +59,8 @@ end
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 296323 then -- Activate Omega buster
-		self:Bar(291928, 16) -- Giga-Zap
-		self:Bar(283551, 40.3) -- Magneto Arm
+		self:Bar(291928, 14.8) -- Giga-Zap
+		self:Bar(283551, 35.6) -- Magneto Arm
 	end
 end
 
@@ -112,7 +113,7 @@ end
 function mod:TakeOff(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "info")
-	self:CDBar(args.spellId, 37)
+	self:CDBar(args.spellId, 34)
 end
 
 function mod:CuttingBeam(args)
@@ -124,8 +125,11 @@ end
 function mod:MagnetoArm(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
-	self:CastBar(args.spellId, 9)
 	self:Bar(args.spellId, 62)
+end
+
+function mod:MagnetoArmSuccess(args)
+	self:CastBar(283551, 9)
 end
 
 function mod:ProtocolNinetyNine(args)

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -31,7 +31,7 @@ function mod:GetOptions()
 		291613, -- Take Off!
 		291626, -- Cutting Beam
 		283551, -- Magneto-Arm
-		292290, -- Protocol: Ninety-Nine XXX check spell id. only cast when tank is out of range.
+		292290, -- Protocol: Ninety-Nine
 		292750, -- H.A.R.D.M.O.D.E.
 	}
 end

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -27,6 +27,7 @@ function mod:GetOptions()
 		291626, -- Cutting Beam
 		283551, -- Magneto-Arm
 		292290, -- Protocol: Ninety-Nine
+		-- Hard Mode
 		292750, -- H.A.R.D.M.O.D.E.
 	}
 end

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -49,7 +49,7 @@ end
 
 do
 	local function startTimer()
-		if mod:GetBossId(151168) then
+		if mod:GetBossId(151168) then -- Annihilo-tron 5000, only active on hard mode
 			mod:Bar(292750, 32.1) -- H.A.R.D.M.O.D.E.
 		end
 	end

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -1,9 +1,4 @@
 --------------------------------------------------------------------------------
--- TODO
--- Don't show hard mode timer when hard mode is not active
---
-
---------------------------------------------------------------------------------
 -- Module Declaration
 --
 
@@ -43,7 +38,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "GigaZap", 291928, 292264) -- Stage 1, stage 2
 	self:Log("SPELL_CAST_START", "TakeOff", 291613)
 	self:Log("SPELL_CAST_SUCCESS", "CuttingBeam", 291626)
-	self:Log("SPELL_CAST_SUCCESS", "MagnetoArm", 283551) -- Boss' cast activating the device
+	self:Log("SPELL_CAST_SUCCESS", "MagnetoArm", 283551) -- Boss's cast activating the device
 	self:Log("SPELL_CAST_SUCCESS", "MagnetoArmSuccess", 283143) -- Pull in effect start
 	self:Log("SPELL_CAST_START", "ProtocolNinetyNine", 292290)
 
@@ -51,14 +46,21 @@ function mod:OnBossEnable()
 	self:Death("OmegaBusterDeath", 144249)
 end
 
-function mod:OnEngage()
-	stage = 1
-	gigaZapCount = 0
-	self:Bar(291865, 5.9) -- Recalibrate
-	self:Bar(291928, 8.4) -- Giga-Zap
-	self:Bar(291613, 30) -- Take Off
-	self:Bar(292750, 32.2) -- H.A.R.D.M.O.D.E.
+do
+	local function startTimer()
+		if mod:GetBossId(151168) then
+			mod:Bar(292750, 32.1) -- H.A.R.D.M.O.D.E.
+		end
+	end
 
+	function mod:OnEngage()
+		stage = 1
+		gigaZapCount = 0
+		self:SimpleTimer(startTimer, 0.1)
+		self:Bar(291865, 5.9) -- Recalibrate
+		self:Bar(291928, 8.4) -- Giga-Zap
+		self:Bar(291613, 30) -- Take Off
+	end
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -74,7 +74,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	elseif spellId == 292750 then -- H.A.R.D.M.O.D.E.
 		self:Message2(292750, "cyan")
 		self:PlaySound(292750, "long")
-		self:CDBar(292750, 43)
+		self:CDBar(292750, 43.7)
 	end
 end
 

--- a/BfA/Mechagon/KingMechagon.lua
+++ b/BfA/Mechagon/KingMechagon.lua
@@ -1,4 +1,9 @@
 --------------------------------------------------------------------------------
+-- TODO
+-- Don't show hard mode timer when hard mode is not active
+--
+
+--------------------------------------------------------------------------------
 -- Module Declaration
 --
 
@@ -27,11 +32,12 @@ function mod:GetOptions()
 		291626, -- Cutting Beam
 		283551, -- Magneto-Arm
 		292290, -- Protocol: Ninety-Nine XXX check spell id. only cast when tank is out of range.
+		292750, -- H.A.R.D.M.O.D.E.
 	}
 end
 
 function mod:OnBossEnable()
-	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1")
+	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1", "boss2", "boss3")
 
 	self:Log("SPELL_CAST_START", "Recalibrate", 291865)
 	self:Log("SPELL_CAST_START", "GigaZap", 291928, 292264) -- Stage 1, stage 2
@@ -51,6 +57,8 @@ function mod:OnEngage()
 	self:Bar(291865, 5.9) -- Recalibrate
 	self:Bar(291928, 8.4) -- Giga-Zap
 	self:Bar(291613, 30) -- Take Off
+	self:Bar(292750, 32.2) -- H.A.R.D.M.O.D.E.
+
 end
 
 --------------------------------------------------------------------------------
@@ -61,6 +69,10 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 296323 then -- Activate Omega buster
 		self:Bar(291928, 14.8) -- Giga-Zap
 		self:Bar(283551, 35.6) -- Magneto Arm
+	elseif spellId == 292750 then -- H.A.R.D.M.O.D.E.
+		self:Message2(292750, "cyan")
+		self:PlaySound(292750, "long")
+		self:CDBar(292750, 43)
 	end
 end
 

--- a/BfA/Mechagon/MachinistsGarden.lua
+++ b/BfA/Mechagon/MachinistsGarden.lua
@@ -43,7 +43,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 294853 then -- Activate Plant
 		self:Message2(spellId, "orange")
 		self:PlaySound(spellId, "long")
-		self:Bar(spellId, 46.2)
+		self:Bar(spellId, 45)
 	end
 end
 
@@ -57,7 +57,7 @@ end
 function mod:HiddenFlameCannon(args)
 	self:Message2(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
-	self:CastBar(args.spellId, 13.5)
+	self:CastBar(args.spellId, 12.5)
 	self:Bar(args.spellId, 47.3)
 end
 

--- a/BfA/Mechagon/OppressionUnit.lua
+++ b/BfA/Mechagon/OppressionUnit.lua
@@ -25,7 +25,7 @@ function mod:GetOptions()
 		301351, -- Reinforcement Relay
 		296522, -- Self-Destruct
 		296080, -- Haywire
-		-- Hardmode
+		-- Hard Mode
 		303885, -- Fulminating Burst
 	}
 end

--- a/BfA/Mechagon/OppressionUnit.lua
+++ b/BfA/Mechagon/OppressionUnit.lua
@@ -41,7 +41,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	self:Bar(301351, 23.9) -- Reinforcement Relay
+	self:Bar(301351, 21.4) -- Reinforcement Relay
 end
 
 --------------------------------------------------------------------------------

--- a/BfA/Mechagon/OppressionUnit.lua
+++ b/BfA/Mechagon/OppressionUnit.lua
@@ -101,7 +101,7 @@ end
 function mod:FulminatingBurstApplied(args)
 	self:TargetMessage2(args.spellId, "orange", args.destName)
 	self:PlaySound(args.spellId, "info", nil, args.destName)
-	self:TargetBar(args.spellid, 9)
+	self:TargetBar(args.spellId, 9)
 end
 
 function mod:FulminatingBurstRemoved(args)

--- a/BfA/Mechagon/OppressionUnit.lua
+++ b/BfA/Mechagon/OppressionUnit.lua
@@ -25,6 +25,8 @@ function mod:GetOptions()
 		301351, -- Reinforcement Relay
 		296522, -- Self-Destruct
 		296080, -- Haywire
+		-- Hardmode
+		303885, -- Fulminating Burst
 	}
 end
 
@@ -36,6 +38,8 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "LiftOff", 301177)
 	self:Log("SPELL_AURA_APPLIED", "HaywireApplied", 296080)
 	self:Log("SPELL_CAST_START", "AnnihilationRay", 295939)
+	self:Log("SPELL_AURA_APPLIED", "FulminatingBurstApplied", 303885)
+	self:Log("SPELL_AURA_REMOVED", "FulminatingBurstRemoved", 303885)
 
 	self:Death("TankBusterDeath", 150295)
 end
@@ -92,4 +96,14 @@ function mod:HaywireApplied(args)
 	self:Message2(args.spellId, "cyan", CL.onboss:format(args.spellName))
 	self:PlaySound(args.spellId, "long")
 	self:TargetBar(args.spellId, 30, args.destName)
+end
+
+function mod:FulminatingBurstApplied(args)
+	self:TargetMessage2(args.spellId, "orange", args.destName)
+	self:PlaySound(args.spellId, "info", nil, args.destName)
+	self:TargetBar(args.spellid, 9)
+end
+
+function mod:FulminatingBurstRemoved(args)
+	self:StopBar(args.spellId, args.destName)
 end

--- a/BfA/Mechagon/OppressionUnit.lua
+++ b/BfA/Mechagon/OppressionUnit.lua
@@ -85,7 +85,7 @@ end
 function mod:LiftOff(args)
 	self:Message2("stages", "cyan", CL.stage:format(1), false)
 	self:PlaySound("stages", "long")
-	self:Bar(301351, 32.8) -- Reinforcement Relay
+	self:Bar(301351, 31.5) -- Reinforcement Relay
 end
 
 function mod:HaywireApplied(args)

--- a/BfA/Mechagon/Options/Colors.lua
+++ b/BfA/Mechagon/Options/Colors.lua
@@ -28,12 +28,13 @@ BigWigs:AddColors("HK-8 Aerial Oppression Unit", {
 	[296080] = "cyan",
 	[301351] = "orange",
 	[302274] = {"blue","orange"},
+	[303885] = {"blue","orange"},
 	["stages"] = "cyan",
 })
 
 BigWigs:AddColors("Tussle Tonks", {
 	[282801] = {"blue","green"},
-	[283421] = {"blue","yellow"},
+	[283422] = {"blue","yellow"},
 	[285020] = "red",
 	[285152] = {"blue","yellow"},
 	[285344] = "orange",
@@ -61,6 +62,7 @@ BigWigs:AddColors("King Mechagon", {
 	[291865] = "orange",
 	[291928] = {"blue","red"},
 	[292290] = "yellow",
+	[292750] = "cyan",
 	["stages"] = "cyan",
 })
 
@@ -75,6 +77,7 @@ BigWigs:AddColors("Operation: Mechagon Trash", {
 	[293986] = "red",
 	[294015] = "yellow",
 	[294103] = "orange",
+	[294180] = {"blue","orange"},
 	[294195] = {"blue","yellow"},
 	[294290] = "orange",
 	[294324] = "red",

--- a/BfA/Mechagon/Options/Sounds.lua
+++ b/BfA/Mechagon/Options/Sounds.lua
@@ -28,12 +28,13 @@ BigWigs:AddSounds("HK-8 Aerial Oppression Unit", {
 	[296080] = "long",
 	[301351] = "alarm",
 	[302274] = "info",
+	[303885] = "info",
 	["stages"] = "long",
 })
 
 BigWigs:AddSounds("Tussle Tonks", {
 	[282801] = "long",
-	[283421] = "alert",
+	[283422] = "alert",
 	[285020] = "alert",
 	[285152] = "alert",
 	[285344] = "info",
@@ -61,6 +62,7 @@ BigWigs:AddSounds("King Mechagon", {
 	[291865] = "alert",
 	[291928] = "alarm",
 	[292290] = "warning",
+	[292750] = "long",
 	["stages"] = "long",
 })
 
@@ -75,6 +77,7 @@ BigWigs:AddSounds("Operation: Mechagon Trash", {
 	[293986] = "alarm",
 	[294015] = "info",
 	[294103] = "alarm",
+	[294180] = "alert",
 	[294195] = "alert",
 	[294290] = "info",
 	[294324] = "alarm",

--- a/BfA/Mechagon/Trash.lua
+++ b/BfA/Mechagon/Trash.lua
@@ -2,6 +2,7 @@
 -- TODO
 -- Walkie Shockie X1 spawn warning and fixate nameplate icons
 -- Scrapbone Grunter fixate nameplate icons
+-- Add Junkyard D.0.G. spells
 --
 
 --------------------------------------------------------------------------------

--- a/BfA/Mechagon/Trash.lua
+++ b/BfA/Mechagon/Trash.lua
@@ -204,11 +204,11 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "RippingSlashApplied", 299474)
 	-- Malfunctioning Scrapbot
 	self:Log("SPELL_CAST_START", "MalfunctioningExhaust", 300102)
-	self:Log("SPELL_CAST_SUCCESS", "MalfunctioningGyroScrap", 294884)
+	self:Log("SPELL_CAST_START", "MalfunctioningGyroScrap", 294884)
 	self:Log("SPELL_CAST_START", "SelfDestructProtocol", 300129)
 	-- Heavy Scrapbot
 	self:Log("SPELL_CAST_START", "HeavyExhaust", 300177)
-	self:Log("SPELL_CAST_SUCCESS", "HeavyGyroScrap", 300159)
+	self:Log("SPELL_CAST_START", "HeavyGyroScrap", 300159)
 	self:Log("SPELL_CAST_START", "RepairProtocol", 300171)
 	-- Pistonhead Blaster
 	self:Log("SPELL_CAST_SUCCESS", "ScrapGrenade", 299525)

--- a/BfA/Mechagon/Trash.lua
+++ b/BfA/Mechagon/Trash.lua
@@ -2,7 +2,6 @@
 -- TODO
 -- Walkie Shockie X1 spawn warning and fixate nameplate icons
 -- Scrapbone Grunter fixate nameplate icons
--- Add Junkyard D.0.G. spells
 --
 
 --------------------------------------------------------------------------------
@@ -42,7 +41,9 @@ mod:RegisterEnableMob(
 	144298, -- Defense Bot Mk III
 	151476, -- Blastatron X-80
 	144295, -- Mechagon Mechanic
-	144299 -- Workshop Defender
+	144299, -- Workshop Defender
+	144296, -- Spider Tank
+	151773  -- Junkyard D.0.G.
 )
 
 --------------------------------------------------------------------------------
@@ -79,6 +80,7 @@ if L then
 	L.blastatron_x80 = "Blastatron X-80"
 	L.mechagon_mechanic = "Mechagon Mechanic"
 	L.workshop_defender = "Workshop Defender"
+	L.junkyard_d0g = "Junkyard D.0.G."
 end
 
 --------------------------------------------------------------------------------
@@ -159,6 +161,8 @@ function mod:GetOptions()
 		-- Workshop Defender
 		{293670, "TANK_HEALER"}, -- Chainblade
 		293683, -- Shield Generator
+		-- Junkyard D.0.G.
+		{294180, "DISPEL"}, -- Flaming Refuse
 	}, {
 		[300436] = L.scrapbone_shaman,
 		[300414] = L.scrapbone_grinder,
@@ -186,6 +190,7 @@ function mod:GetOptions()
 		[294015] = L.blastatron_x80,
 		[293729] = L.mechagon_mechanic,
 		[293670] = L.workshop_defender,
+		[294180] = L.junkyard_d0g,
 	}
 end
 
@@ -277,6 +282,8 @@ function mod:OnBossEnable()
 	-- Workshop Defender
 	self:Log("SPELL_AURA_APPLIED", "ChainbladeApplied", 293670)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "ChainbladeApplied", 293670)
+	-- Junkyard D.0.G.
+	self:Log("SPELL_AURA_APPLIED", "FlamingRefuseApplied", 294180)
 end
 
 --------------------------------------------------------------------------------
@@ -725,4 +732,13 @@ end
 function mod:ChainbladeApplied(args)
 	self:StackMessage(args.spellId, args.destName, args.amount, "red")
 	self:PlaySound(args.spellId, "alert", nil, args.destName)
+end
+
+-- Junkyard D.0.G.
+
+function mod:FlamingRefuseApplied(args)
+	if self:Dispeller("magic") then
+		self:TargetMessage2(args.spellId, "orange", args.destName)
+		self:PlaySound(args.spellId, "alert", nil, args.destName)
+	end
 end

--- a/BfA/Mechagon/TrixieNaeno.lua
+++ b/BfA/Mechagon/TrixieNaeno.lua
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------------
 -- TODO
--- Roadkill timer
+-- Mega Taze timer
 -- Bolt Buster timer
 --
 
@@ -37,10 +37,14 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "Burnout", 298571)
 	self:Log("SPELL_CAST_SUCCESS", "RollOut", 298898)
 	self:Log("SPELL_CAST_START", "PedaltotheMetal", 298651, 299164) -- First cast, second cast
+
+	self:Death("TrixieDeath", 150712)
+	self:Death("NaenoDeath", 153755)
 end
 
 function mod:OnEngage()
 	self:Bar(302682, 26.4) -- Mega Taze
+	self:Bar(298946, 30) -- Roadkill
 end
 
 --------------------------------------------------------------------------------
@@ -72,6 +76,7 @@ end
 function mod:Roadkill(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alert")
+	self:Bar(args.spellId, 52.3)
 end
 
 function mod:BoltBuster(args)
@@ -94,4 +99,12 @@ function mod:PedaltotheMetal(args)
 	self:Message2(298651, "red")
 	self:PlaySound(298651, "alert")
 	self:CastBar(298651, 4.5) -- Pedal to the Metal
+end
+
+function mod:TrixieDeath(args)
+	self:StopBar(302682) -- Mega Taze
+end
+
+function mod:NaenoDeath(args)
+	self:StopBar(298946) -- Roadkill
 end

--- a/BfA/Mechagon/TrixieNaeno.lua
+++ b/BfA/Mechagon/TrixieNaeno.lua
@@ -1,7 +1,6 @@
 --------------------------------------------------------------------------------
 -- TODO
 -- Mega Taze timer
--- Bolt Buster timer
 --
 
 --------------------------------------------------------------------------------
@@ -45,6 +44,7 @@ end
 function mod:OnEngage()
 	self:Bar(302682, 26.4) -- Mega Taze
 	self:Bar(298946, 30) -- Roadkill
+	self:Bar(298940, 35.1) -- Bolt Buster
 end
 
 --------------------------------------------------------------------------------
@@ -82,6 +82,7 @@ end
 function mod:BoltBuster(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alert")
+	self:Bar(args.spellId, 52.3)
 end
 
 function mod:Burnout(args)

--- a/BfA/Mechagon/TussleTonks.lua
+++ b/BfA/Mechagon/TussleTonks.lua
@@ -20,7 +20,7 @@ function mod:GetOptions()
 		-- Gnomercy 4.U.
 		{285152, "SAY", "FLASH"}, -- Foe Flipper
 		285388, -- Vent Jets
-		{283421, "SAY", "FLASH"}, -- Maximum Thrust
+		{283422, "SAY", "FLASH"}, -- Maximum Thrust
 	}
 end
 
@@ -32,7 +32,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "FoeFlipper", 285152)
 	self:Log("SPELL_CAST_START", "VentJets", 285388)
 	self:Log("SPELL_CAST_SUCCESS", "VentJetsSuccess", 285388)
-	self:Log("SPELL_CAST_START", "MaximumThrust", 283421)
+	self:Log("SPELL_CAST_START", "MaximumThrust", 283422)
 end
 
 function mod:OnEngage()
@@ -95,11 +95,11 @@ end
 
 do
 	local function printTarget(self, name, guid)
-		self:TargetMessage2(283421, "yellow", name)
-		self:PlaySound(283421, "alert", nil, name)
+		self:TargetMessage2(283422, "yellow", name)
+		self:PlaySound(283422, "alert", nil, name)
 		if self:Me(guid) then
-			self:Say(283421)
-			self:Flash(283421)
+			self:Say(283422)
+			self:Flash(283422)
 		end
 	end
 

--- a/BfA/Mechagon/TussleTonks.lua
+++ b/BfA/Mechagon/TussleTonks.lua
@@ -44,9 +44,17 @@ end
 -- Event Handlers
 --
 
-function mod:PlatinumPlatingRemoved(args)
-	self:StackMessage(args.spellId, args.destName, args.amount, "green")
-	self:PlaySound(args.spellId, "long")
+do
+	-- If the event fires more than once, args.amount is the same for both events
+	local prev = 0
+	function mod:PlatinumPlatingRemoved(args)
+		local t = args.time
+		if t-prev > 0.1 then
+			prev = t
+			self:StackMessage(args.spellId, args.destName, args.amount, "green")
+			self:PlaySound(args.spellId, "long")
+		end
+	end
 end
 
 function mod:WhirlingEdge(args)


### PR DESCRIPTION
**TrixieNaeno**
- Add Roadkill timer
- Add Bolt Buster timer

**OppressionUnit**
- Fix reinforcement relay timer
- Add Fulminating Burst (hard mode)

**TussleTonks**
- Fix Maximum Thrust spell id
- Throttle Platinum Plating message

**KUJ0**
- Add Explosive Leap proximity

**MachinistsGarden**
- Fix timers

**KingMechagon**
- Fix timers
- Add H.A.R.D.M.O.D.E. timer

**Trash**
- Add Junkyard D.0.G.