### PR TITLE
BfA/ShrineOfTheStorm/Trash: Add debug message for Void Seed

### DIFF
--- a/BfA/ShrineOfTheStorm/Trash.lua
+++ b/BfA/ShrineOfTheStorm/Trash.lua
@@ -288,8 +288,26 @@ function mod:VoidSeedApplied(args)
 		local _, _, _, expirationTime = self:UnitDebuff(args.destName, args.spellId)
 		if expirationTime then
 			local duration = expirationTime - GetTime()
-			self:TargetBar(args.spellId, duration, args.destName)
-			self:SayCountdown(args.spellId, duration)
+			if duration >= 0 then
+				self:TargetBar(args.spellId, duration, args.destName)
+				self:SayCountdown(args.spellId, duration)
+			else
+				local count = 0
+				local maxExpirationTime = 0
+				for i = 1, 100 do
+					local _, _, _, _, _, currentExpirationTime, _, _, _, spellId = UnitAura(args.destName, i, "HARMFUL")
+					if spellId == args.spellId then
+						count = count + 1
+						if currentExpirationTime > maxExpirationTime then
+							maxExpirationTime = currentExpirationTime
+						end
+					end
+				end
+				print(string.format(
+					"BigWigs: |cffffff00 Void seed applied: count: %d, duration: %d, max duration: %d. Tell the authors!|r",
+					count, duration, maxExpirationTime - GetTime()
+				))
+			end
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Trash.lua
+++ b/BfA/ShrineOfTheStorm/Trash.lua
@@ -291,20 +291,23 @@ function mod:VoidSeedApplied(args)
 			local _, _, _, _, _, expirationTime, _, _, _, spellId = UnitAura(args.destName, i, "HARMFUL")
 			if spellId == args.spellId then
 				count = count + 1
+				if count > 1 then
+					BigWigs:Error(string.format(
+					"Void seed applied: count: %d, duration: %d, previous max duration: %d. Tell the authors!",
+					count, expirationTime - GetTime(), maxExpirationTime - GetTime()
+				))
+				end
 				if expirationTime > maxExpirationTime then
 					maxExpirationTime = expirationTime
 				end
+			elseif not spellId then
+				break
 			end
 		end
 		local duration = maxExpirationTime - GetTime()
 		if duration >= 0 then
 			self:TargetBar(args.spellId, duration, args.destName)
 			self:SayCountdown(args.spellId, duration)
-		else
-			BigWigs:Error(string.format(
-				"Void seed applied: count: %d, duration: %d, max duration: %d. Tell the authors!",
-				count, duration, maxExpirationTime - GetTime()
-			))
 		end
 	end
 end

--- a/BfA/ShrineOfTheStorm/Trash.lua
+++ b/BfA/ShrineOfTheStorm/Trash.lua
@@ -293,9 +293,9 @@ function mod:VoidSeedApplied(args)
 				count = count + 1
 				if count > 1 then
 					BigWigs:Error(string.format(
-					"Void seed applied: count: %d, duration: %d, previous max duration: %d. Tell the authors!",
-					count, expirationTime - GetTime(), maxExpirationTime - GetTime()
-				))
+						"Void seed applied: count: %d, duration: %d, previous max duration: %d. Tell the authors!",
+						count, expirationTime - GetTime(), maxExpirationTime - GetTime()
+					))
 				end
 				if expirationTime > maxExpirationTime then
 					maxExpirationTime = expirationTime

--- a/BfA/ShrineOfTheStorm/Trash.lua
+++ b/BfA/ShrineOfTheStorm/Trash.lua
@@ -285,29 +285,26 @@ function mod:VoidSeedApplied(args)
 		self:TargetMessage(args.spellId, args.destName, "blue")
 		self:PlaySound(args.spellId, "alarm")
 		-- Duration seems to vary, so we can't hardcode a fixed duration
-		local _, _, _, expirationTime = self:UnitDebuff(args.destName, args.spellId)
-		if expirationTime then
-			local duration = expirationTime - GetTime()
-			if duration >= 0 then
-				self:TargetBar(args.spellId, duration, args.destName)
-				self:SayCountdown(args.spellId, duration)
-			else
-				local count = 0
-				local maxExpirationTime = 0
-				for i = 1, 100 do
-					local _, _, _, _, _, currentExpirationTime, _, _, _, spellId = UnitAura(args.destName, i, "HARMFUL")
-					if spellId == args.spellId then
-						count = count + 1
-						if currentExpirationTime > maxExpirationTime then
-							maxExpirationTime = currentExpirationTime
-						end
-					end
+		local count = 0
+		local maxExpirationTime = 0
+		for i = 1, 100 do
+			local _, _, _, _, _, expirationTime, _, _, _, spellId = UnitAura(args.destName, i, "HARMFUL")
+			if spellId == args.spellId then
+				count = count + 1
+				if expirationTime > maxExpirationTime then
+					maxExpirationTime = expirationTime
 				end
-				print(string.format(
-					"BigWigs: |cffffff00 Void seed applied: count: %d, duration: %d, max duration: %d. Tell the authors!|r",
-					count, duration, maxExpirationTime - GetTime()
-				))
 			end
+		end
+		local duration = maxExpirationTime - GetTime()
+		if duration >= 0 then
+			self:TargetBar(args.spellId, duration, args.destName)
+			self:SayCountdown(args.spellId, duration)
+		else
+			BigWigs:Error(string.format(
+				"Void seed applied: count: %d, duration: %d, max duration: %d. Tell the authors!",
+				count, duration, maxExpirationTime - GetTime()
+			))
 		end
 	end
 end


### PR DESCRIPTION
Prints when more than one void seed is active at a time