### PR TITLE
BfA/ShrineOfTheStorm: Fix warmup timers

### DIFF
--- a/BfA/ShrineOfTheStorm/Aqusirr.lua
+++ b/BfA/ShrineOfTheStorm/Aqusirr.lua
@@ -5,7 +5,8 @@
 
 local mod, CL = BigWigs:NewBoss("Aqu'sirr", 1864, 2153)
 if not mod then return end
-mod:RegisterEnableMob(134056, 139737) -- Aqu'sirr, Stormsong (for warmup timer)
+-- Enable on trash before the boss to be sure the module is enabled for the warmup RP.
+mod:RegisterEnableMob(134056, 139737, 134173) -- Aqu'sirr, Stormsong (for warmup timer), Animated Droplet (for warmup tiemr)
 mod.engageId = 2130
 mod.respawnTime = 30
 

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -5,7 +5,8 @@
 
 local mod, CL = BigWigs:NewBoss("Lord Stormsong", 1864, 2155)
 if not mod then return end
-mod:RegisterEnableMob(134060)
+-- Enable on trash before the boss to be sure the module is enabled for the warmup RP.
+mod:RegisterEnableMob(134060, 134423) -- Lord Stormsong, Abyss Dweller
 mod.engageId = 2132
 mod.respawnTime = 30
 


### PR DESCRIPTION
You don't have to mouse over or target the NPCs that do the RP in order to start the RP, so the module is frequently not enabled when the RP starts. Instead, enable on the trash pack before the boss.