### PR TITLE
BfA/WaycrestManor/Heartsbane: Improve timers

### DIFF
--- a/BfA/WaycrestManor/Heartsbane.lua
+++ b/BfA/WaycrestManor/Heartsbane.lua
@@ -21,56 +21,110 @@ local playersWithRunicMark = 0
 
 function mod:GetOptions()
 	return {
+		-- General
 		{260805, "ICON"}, -- Focusing Iris
 		260773, -- Dire Ritual
-		260741, -- Jagged Nettles
+		-- Sister Solena
+		{260907, "ICON"}, -- Soul Manipulation
+		-- Sister Malady
 		{260703, "SAY", "SAY_COUNTDOWN", "FLASH", "PROXIMITY"}, -- Unstable Runic Mark
 		268086, -- Aura of Dread
-		{260926, "ICON"}, -- Soul Manipulation
+		-- Sister Briar
+		260741, -- Jagged Nettles
 	}, {
 		[260805] = "general",
-		[260741] = -17738, -- Sister Briar,
+		[260907] = -17740, -- Sister Solena
 		[260703] = -17739, -- Sister Malady
-		[260926] = -17740, -- Sister Solena
+		[260741] = -17738, -- Sister Briar
 	}
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_CAST_START", "JaggedNettles", 260741)
+	self:Log("SPELL_AURA_REMOVED", "ArmorRemoved", 260907, 261266, 261265)
+	self:Log("SPELL_AURA_APPLIED", "FocusingIris", 260805)
+	self:Log("SPELL_CAST_START", "DireRitual", 260773)
+	self:Log("SPELL_CAST_START", "SoulManipulation", 260907)
+	self:Log("SPELL_AURA_APPLIED", "SoulManipulationApplied", 260926)
+	self:Log("SPELL_AURA_REMOVED", "SoulManipulationRemovedFromBoss", 260923)
+	self:Log("SPELL_AURA_APPLIED_DOSE", "AuraOfDread", 268086)
 	self:Log("SPELL_CAST_SUCCESS", "UnstableRunicMark", 260703)
 	self:Log("SPELL_AURA_APPLIED", "UnstableRunicMarkApplied", 260703)
 	self:Log("SPELL_AURA_REMOVED", "UnstableRunicMarkRemoved", 260703)
-	self:Log("SPELL_AURA_APPLIED", "SoulManipulation", 260926)
-	self:Log("SPELL_AURA_REMOVED", "SoulManipulationRemovedFromBoss", 260923)
-	self:Log("SPELL_AURA_APPLIED_DOSE", "AuraOfDread", 268086)
-	self:Log("SPELL_AURA_APPLIED", "FocusingIris", 260805)
-	self:Log("SPELL_CAST_START", "DireRitual", 260773)
+	self:Log("SPELL_CAST_START", "JaggedNettles", 260741)
 end
 
 function mod:OnEngage()
 	playersWithRunicMark = 0
+	self:Bar(260907, 8.5) -- Soul Manipulation
+	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 end
 
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
 
-do
-	local function printTarget(self, name, guid)
-		self:TargetMessage2(260741, "orange", name) -- Jagged Nettles
-		self:PlaySound(260741, "alarm", nil, name) -- Jagged Nettles
+function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
+	local unit = self:GetBossId(131824) -- Sister Solena
+	if unit then
+		self:PrimaryIcon(260805, unit) -- Focusing Iris
+		self:UnregisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 	end
+end
 
-	function mod:JaggedNettles(args)
-		self:GetBossTarget(printTarget, 0.4, args.sourceGUID)
-		self:Bar(args.spellId, 13.5)
+function mod:ArmorRemoved(args)
+	self:Message2(260805, "cyan", CL.removed_from:format(args.spellName, args.destName)) -- Focusing Iris
+	self:PlaySound(260805, "long") -- Focusing Iris
+	self:PrimaryIcon(260805, self:GetBossId(args.destGUID)) -- Focusing Iris
+	self:StopBar(260741) -- Jagged Nettles
+	self:StopBar(260703) -- Unstable Runic Mark
+	self:StopBar(260907) -- Soul Manipulation
+end
+
+function mod:FocusingIris(args)
+	local mobId = self:MobId(args.destGUID)
+	if mobId == 131825 then -- Sister Briar
+		self:Bar(260741, 8.5)  -- Jagged Nettles
+	elseif mobId == 131823 then -- Sister Malady
+		self:Bar(260703, 9) -- Unstable Runic Mark
+	elseif mobId == 131824 then -- Sister Solena
+		self:Bar(260907, 8.5) -- Soul Manipulation
+	end
+end
+
+function mod:DireRitual(args)
+	self:Message2(args.spellId, "red")
+	self:PlaySound(args.spellId, "warning")
+end
+
+function mod:SoulManipulation(args)
+	self:Bar(args.spellId, 25.5)
+	self:CastBar(args.spellId, 2)
+end
+
+function mod:SoulManipulationApplied(args)
+	self:TargetMessage2(260907, "orange", args.destName) -- Soul Manipulation
+	self:PlaySound(260907, "alarm", nil, args.destName) -- Soul Manipulation
+	self:PrimaryIcon(260907, args.destName) -- Soul Manipulation, Move icon from boss to player
+end
+
+function mod:SoulManipulationRemovedFromBoss(args)
+	-- Move the icon away from the player and back to the boss
+	self:PrimaryIcon(260805, self:GetBossId(args.destGUID)) -- Focusing Iris
+end
+
+function mod:AuraOfDread(args)
+	if self:Me(args.destGUID) then
+		if args.amount % 3 == 0 or args.amount > 6 then
+			self:StackMessage(args.spellId, args.destName, args.amount, "blue")
+			self:PlaySound(args.spellId, args.amount > 6 and "warning" or "alert")
+		end
 	end
 end
 
 function mod:UnstableRunicMark(args)
 	self:Message2(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm")
-	-- self:Bar(args.spellId, 13.5) XXX Need a timer
+	self:Bar(args.spellId, 12)
 end
 
 function mod:UnstableRunicMarkApplied(args)
@@ -95,41 +149,14 @@ function mod:UnstableRunicMarkRemoved(args)
 	end
 end
 
-function mod:SoulManipulation(args)
-	self:TargetMessage2(args.spellId, "orange", args.destName)
-	self:PlaySound(args.spellId, "alarm", nil, args.destName)
-	self:PrimaryIcon(args.spellId, args.destName) -- Move icon from boss to player
-end
-
-function mod:SoulManipulationRemovedFromBoss(args)
-	-- Move the icon away from the player and back to the boss
-	self:PrimaryIcon(260805, self:GetBossId(args.destGUID)) -- Focusing Iris
-end
-
-function mod:AuraOfDread(args)
-	if self:Me(args.destGUID) then
-		if args.amount % 3 == 0 or args.amount > 6 then
-			self:StackMessage(args.spellId, args.destName, args.amount, "blue")
-			self:PlaySound(args.spellId, args.amount > 6 and "warning" or "alert")
-		end
+do
+	local function printTarget(self, name, guid)
+		self:TargetMessage2(260741, "orange", name) -- Jagged Nettles
+		self:PlaySound(260741, "alarm", nil, name) -- Jagged Nettles
 	end
-end
 
-function mod:FocusingIris(args)
-	self:Message2(args.spellId, "cyan", CL.other:format(args.spellName, args.destName))
-	self:PlaySound(args.spellId, "long")
-	self:PrimaryIcon(args.spellId, self:GetBossId(args.destGUID))
-	self:StopBar(260741) -- Jagged Nettles
-	self:StopBar(260703) -- Unstable Runic Mark
-
-	if self:MobId(args.destGUID) == 131825 then -- Sister Briar
-		self:Bar(260741, 8.5)  -- Jagged Nettles
-	elseif self:MobId(args.destGUID) == 131823 then -- Sister Malady
-		self:Bar(260703, 9) -- Unstable Runic Mark
+	function mod:JaggedNettles(args)
+		self:GetBossTarget(printTarget, 0.4, args.sourceGUID)
+		self:Bar(args.spellId, 13.5)
 	end
-end
-
-function mod:DireRitual(args)
-	self:Message2(args.spellId, "red")
-	self:PlaySound(args.spellId, "warning")
 end

--- a/BfA/WaycrestManor/Heartsbane.lua
+++ b/BfA/WaycrestManor/Heartsbane.lua
@@ -40,7 +40,7 @@ function mod:GetOptions()
 end
 
 function mod:OnBossEnable()
-	self:Log("SPELL_AURA_REMOVED", "ArmorRemoved", 260907, 261266, 261265)
+	self:Log("SPELL_CAST_SUCCESS", "ClaimTheIris", 260852)
 	self:Log("SPELL_AURA_APPLIED", "FocusingIris", 260805)
 	self:Log("SPELL_CAST_START", "DireRitual", 260773)
 	self:Log("SPELL_CAST_START", "SoulManipulation", 260907)
@@ -56,25 +56,16 @@ end
 function mod:OnEngage()
 	playersWithRunicMark = 0
 	self:Bar(260907, 8.5) -- Soul Manipulation
-	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 end
 
 --------------------------------------------------------------------------------
 -- Event Handlers
 --
 
-function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
-	local unit = self:GetBossId(131824) -- Sister Solena
-	if unit then
-		self:PrimaryIcon(260805, unit) -- Focusing Iris
-		self:UnregisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
-	end
-end
-
-function mod:ArmorRemoved(args)
-	self:Message2(260805, "cyan", CL.removed_from:format(self:SpellName(260805), args.destName)) -- Focusing Iris
+function mod:ClaimTheIris(args)
+	self:Message2(260805, "cyan", CL.other:format(self:SpellName(260805), args.sourceName)) -- Focusing Iris
 	self:PlaySound(260805, "long") -- Focusing Iris
-	self:PrimaryIcon(260805, self:GetBossId(args.destGUID)) -- Focusing Iris
+	self:PrimaryIcon(260805, self:GetBossId(args.sourceGUID)) -- Focusing Iris
 	self:StopBar(260741) -- Jagged Nettles
 	self:StopBar(260703) -- Unstable Runic Mark
 	self:StopBar(260907) -- Soul Manipulation

--- a/BfA/WaycrestManor/Heartsbane.lua
+++ b/BfA/WaycrestManor/Heartsbane.lua
@@ -72,7 +72,7 @@ function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
 end
 
 function mod:ArmorRemoved(args)
-	self:Message2(260805, "cyan", CL.removed_from:format(args.spellName, args.destName)) -- Focusing Iris
+	self:Message2(260805, "cyan", CL.removed_from:format(self:SpellName(260805), args.destName)) -- Focusing Iris
 	self:PlaySound(260805, "long") -- Focusing Iris
 	self:PrimaryIcon(260805, self:GetBossId(args.destGUID)) -- Focusing Iris
 	self:StopBar(260741) -- Jagged Nettles

--- a/BfA/WaycrestManor/Options/Colors.lua
+++ b/BfA/WaycrestManor/Options/Colors.lua
@@ -4,7 +4,7 @@ BigWigs:AddColors("Heartsbane Triad", {
 	[260741] = {"blue","orange"},
 	[260773] = "red",
 	[260805] = "cyan",
-	[260926] = {"blue","orange"},
+	[260907] = {"blue","orange"},
 	[268086] = "blue",
 })
 

--- a/BfA/WaycrestManor/Options/Sounds.lua
+++ b/BfA/WaycrestManor/Options/Sounds.lua
@@ -4,7 +4,7 @@ BigWigs:AddSounds("Heartsbane Triad", {
 	[260741] = "alarm",
 	[260773] = "warning",
 	[260805] = "long",
-	[260926] = "alarm",
+	[260907] = "alarm",
 	[268086] = {"alert","warning"},
 })
 


### PR DESCRIPTION
- Add Soul Manipulation timer and cast bar
- Add timer for Unstable Runic Marks beyond the first
- Move skull marker when the 99% damage reduction is removed
- Reorder functions so abilities for the same boss are together