### PR TITLE
ShrineOfTheStorm/Stormsong: Add a bar for Surrender to the Void, a personal message for Ancient Mindbender's removal, warnings for Twisting Void

### DIFF
--- a/BfA/ShrineOfTheStorm/Options/Colors.lua
+++ b/BfA/ShrineOfTheStorm/Options/Colors.lua
@@ -21,7 +21,8 @@ BigWigs:AddColors("Lord Stormsong", {
 	[268347] = "yellow",
 	[268896] = {"blue","orange"},
 	[269097] = "orange",
-	[269131] = {"blue","red"},
+	[269131] = {"blue","green","red"},
+	[274714] = "blue",
 })
 
 BigWigs:AddColors("Vol'zith the Whisperer", {

--- a/BfA/ShrineOfTheStorm/Options/Sounds.lua
+++ b/BfA/ShrineOfTheStorm/Options/Sounds.lua
@@ -21,7 +21,8 @@ BigWigs:AddSounds("Lord Stormsong", {
 	[268347] = "alert",
 	[268896] = "alert",
 	[269097] = "alarm",
-	[269131] = "warning",
+	[269131] = {"info","warning"},
+	[274714] = "alarm",
 })
 
 BigWigs:AddSounds("Vol'zith the Whisperer", {

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -30,6 +30,7 @@ function mod:GetOptions()
 		268347, -- Void Bolt
 		269097, -- Waken the Void
 		269131, -- Ancient Mindbender
+		274714, -- Twisting Void
 		{268896, "DISPEL"}, -- Mind Rend
 	}, {
 		[268347] = "general",
@@ -44,6 +45,9 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_SUCCESS", "WakentheVoid", 269097)
 	self:Log("SPELL_CAST_SUCCESS", "AncientMindbender", 269131)
 	self:Log("SPELL_AURA_APPLIED", "AncientMindbenderApplied", 269131)
+	self:Log("SPELL_AURA_REMOVED", "AncientMindbenderRemoved", 269131)
+	self:Log("SPELL_PERIODIC_DAMAGE", "TwistingVoid", 274714)
+	self:Log("SPELL_PERIODIC_MISSED", "TwistingVoid", 274714)
 	self:Log("SPELL_AURA_APPLIED", "MindRendApplied", 268896)
 end
 
@@ -86,7 +90,30 @@ end
 
 function mod:AncientMindbenderApplied(args)
 	self:TargetMessage2(args.spellId, "red", args.destName)
+	self:TargetBar(args.spellId, 20, args.destName, 269242) -- Surrender to the Void
 	self:PlaySound(args.spellId, "warning", nil, args.destName)
+end
+
+function mod:AncientMindbenderRemoved(args)
+	self:StopBar(269242, args.destName) -- Surrender to the Void
+	if self:Me(args.destGUID) then
+		self:Message2(args.spellId, "green", CL.removed:format(args.spellName))
+		self:PlaySound(args.spellId, "info")
+	end
+end
+
+do
+	local prev = 0
+	function mod:TwistingVoid(args)
+		if self:Me(args.destGUID) and not self:UnitDebuff("player", 269131) then -- do not display the warning if affected by Mindbender
+			local t = args.time
+			if t - prev > 1.5 then
+				prev = t
+				self:PersonalMessage(args.spellId, "underyou")
+				self:PlaySound(args.spellId, "alarm", "gtfo")
+			end
+		end
+	end
 end
 
 function mod:MindRendApplied(args)

--- a/BfA/ShrineOfTheStorm/Stormsong.lua
+++ b/BfA/ShrineOfTheStorm/Stormsong.lua
@@ -105,7 +105,7 @@ end
 do
 	local prev = 0
 	function mod:TwistingVoid(args)
-		if self:Me(args.destGUID) and not self:UnitDebuff("player", 269131) then -- do not display the warning if affected by Mindbender
+		if self:Me(args.destGUID) then
 			local t = args.time
 			if t - prev > 1.5 then
 				prev = t


### PR DESCRIPTION
Looks like on higher M+ keys people have to dive into the water (Twisting Void) in order to handle the MC mechanic since the orbs do not deal enough damage.