### PR TITLE
Shadowlands/Plaguefall/Trash: Add warnings for "Beckon Slime"

### DIFF
--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -184,8 +184,8 @@ function mod:BelchPlague(args)
 end
 
 function mod:BeckonSlime(args)
-	self:Message(args.spellId, "red")
-	self:PlaySound(args.spellId, "alert")
+	self:Message(args.spellId, "yellow", CL.casting:format(args.spellName))
+	self:PlaySound(args.spellId, "long")
 end
 
 function mod:CorrodedClawsApplied(args)

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -65,6 +65,7 @@ function mod:GetOptions()
 		{327882, "DISPEL"}, -- Blightbeak
 		-- Plaguebelcher
 		327233, -- Belch Plague
+		327584, -- Beckon Slime
 		-- Rotting Slimeclaw
 		{320512, "DISPEL"}, -- Corroded Claws
 		-- Blighted Spinebreaker
@@ -114,6 +115,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "BlightbeakApplied", 327882)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "BlightbeakApplied", 327882)
 	self:Log("SPELL_CAST_START", "BelchPlague", 327233)
+	self:Log("SPELL_CAST_START", "BeckonSlime", 327584)
 	self:Log("SPELL_AURA_APPLIED", "CorrodedClawsApplied", 320512)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "CorrodedClawsApplied", 320512)
 	self:Log("SPELL_CAST_START", "FesteringBelch", 318949)
@@ -179,6 +181,11 @@ function mod:BelchPlague(args)
 		self:Message(args.spellId, "red")
 		self:PlaySound(args.spellId, "alarm")
 	end
+end
+
+function mod:BeckonSlime(args)
+	self:Message(args.spellId, "red")
+	self:PlaySound(args.spellId, "alert")
 end
 
 function mod:CorrodedClawsApplied(args)


### PR DESCRIPTION
I think it would be useful to have https://www.wowhead.com/spell=327233/belch-plague (spell id per my logs) registered on the Plaguebelcher trash mob in Plaguefall, since the slimes usually need to be slowed or cc'ed.

Note that this spell has a different id than Globgrog's Beckon Slime.

I created this PR in my browser using GitHub's edit function -- I haven't tested the Lua and I'm not sure if anything else needs to be changed to register this spell. It would also be lovely to have this spoken aloud by BigWigs_Voice -- will that generate automatically?

![image](https://user-images.githubusercontent.com/44137029/104819922-04a8b200-5829-11eb-946d-5fc81baeeaaa.png)
