### PR TITLE
Split out BfA modules

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -9,3 +9,4 @@ move-folders:
     LittleWigs/MoP: LittleWigs_MistsOfPandaria
     LittleWigs/WoD: LittleWigs_WarlordsOfDraenor
     LittleWigs/Legion: LittleWigs_Legion
+    LittleWigs/BfA: LittleWigs_BattleForAzeroth

--- a/LittleWigs.toc
+++ b/LittleWigs.toc
@@ -19,7 +19,7 @@
 ## X-Curse-Project-ID: 4383
 ## X-WoWI-ID: 9577
 
-## X-BigWigs-LoadOn-InstanceId: 1594, 1754, 1762, 1763, 1771, 1822, 1841, 1862, 1864, 1877, 2097, 2212, 2213, 2284, 2285, 2286, 2287, 2289, 2290, 2291, 2293
+## X-BigWigs-LoadOn-InstanceId: 2284, 2285, 2286, 2287, 2289, 2290, 2291, 2293
 ## Dependencies: BigWigs
 ## LoadOnDemand: 1
 ## Version: @project-version@

--- a/modules.xml
+++ b/modules.xml
@@ -9,8 +9,8 @@
 <Include file="MoP\modules.xml"/>
 <Include file="WoD\modules.xml"/>
 <Include file="Legion\modules.xml"/>
-<!--@end-do-not-package@-->
 <Include file="BfA\modules.xml"/>
+<!--@end-do-not-package@-->
 <Include file="Shadowlands\modules.xml"/>
 
 </Ui>


### PR DESCRIPTION
I don't think loader needs any changes. Kinda forgot about this after SL launched >.>