### PR TITLE
Shadowlands/Plaguefall/Trash: Warn when Stealthlings spawn

### DIFF
--- a/Shadowlands/Plaguefall/Locales/deDE.lua
+++ b/Shadowlands/Plaguefall/Locales/deDE.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Fungumant"
 	L.pestilent_harvester = "Pestilenter Ernter"
 	L.fungi_stormer = "Fungistürmer"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/esES.lua
+++ b/Shadowlands/Plaguefall/Locales/esES.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Fungimántico"
 	L.pestilent_harvester = "Cosechador pestilente"
 	L.fungi_stormer = "Agitador de hongos"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/frFR.lua
+++ b/Shadowlands/Plaguefall/Locales/frFR.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Fongimancien"
 	L.pestilent_harvester = "Moissonneur pestilentiel"
 	L.fungi_stormer = "Tempétueux fongique"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/itIT.lua
+++ b/Shadowlands/Plaguefall/Locales/itIT.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Fungomante"
 	L.pestilent_harvester = "Mietitore Pestilenziale"
 	L.fungi_stormer = "Assaltatore Fungino"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/koKR.lua
+++ b/Shadowlands/Plaguefall/Locales/koKR.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "곰팡이술사"
 	L.pestilent_harvester = "전염성 수확자"
 	L.fungi_stormer = "버섯 번개술사"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/ptBR.lua
+++ b/Shadowlands/Plaguefall/Locales/ptBR.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Fungimante"
 	L.pestilent_harvester = "Ceifador Pestilento"
 	L.fungi_stormer = "Estrondeador Fungal"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/ruRU.lua
+++ b/Shadowlands/Plaguefall/Locales/ruRU.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "Грибомаг"
 	L.pestilent_harvester = "Заразный добытчик"
 	L.fungi_stormer = "Гриб-штурмовик"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/zhCN.lua
+++ b/Shadowlands/Plaguefall/Locales/zhCN.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "菌菇术士"
 	L.pestilent_harvester = "致命的收割者"
 	L.fungi_stormer = "真菌猛攻者"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Locales/zhTW.lua
+++ b/Shadowlands/Plaguefall/Locales/zhTW.lua
@@ -16,4 +16,6 @@ if L then
 	L.fungalmancer = "真菌術師"
 	L.pestilent_harvester = "惡性收割者"
 	L.fungi_stormer = "蘑菇風暴者"
+
+	-- L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
 end

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -79,6 +79,7 @@ function mod:GetOptions()
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
 		328475, -- Enveloping Webbing
+		328400, -- Stealthlings
 		-- Ickor Bileflesh
 		330786, -- Oozing Carcass
 		330816, -- Ghost Step
@@ -125,6 +126,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "WitheringFilth", 321935)
 	self:Log("SPELL_CAST_SUCCESS", "BulwarkOfMaldraxxus", 336451)
 	self:Log("SPELL_CAST_START", "EnvelopingWebbing", 328475)
+	self:Log("SPELL_CAST_SUCCESS", "Stealthlings", 328400)
 	self:Log("SPELL_CAST_START", "OozingCarcass", 330786)
 	self:Log("SPELL_CAST_START", "GhostStep", 330816)
 	self:Log("SPELL_CAST_START", "WonderGrow", 328016)
@@ -248,6 +250,11 @@ end
 function mod:EnvelopingWebbing(args)
 	self:Message(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
+end
+
+function mod:Stealthlings(args)
+	self:Message(args.spellId, "red")
+	self:PlaySound(args.spellId, "warning")
 end
 
 function mod:OozingCarcass(args)

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -46,6 +46,10 @@ if L then
 	L.fungalmancer = "Fungalmancer"
 	L.pestilent_harvester = "Pestilent Harvester"
 	L.fungi_stormer = "Fungi Stormer"
+
+	L.summon_stealthlings = 328400
+	L.summon_stealthlings_desc = "Warnings and timers for when Stealthlings spawn."
+	L.summon_stealthlings_icon = 328400
 end
 
 --------------------------------------------------------------------------------
@@ -79,7 +83,7 @@ function mod:GetOptions()
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
 		328475, -- Enveloping Webbing
-		328400, -- Stealthlings
+		"summon_stealthlings", -- Stealthlings
 		-- Ickor Bileflesh
 		330786, -- Oozing Carcass
 		330816, -- Ghost Step
@@ -253,8 +257,8 @@ function mod:EnvelopingWebbing(args)
 end
 
 function mod:Stealthlings(args)
-	self:Message(args.spellId, "red")
-	self:PlaySound(args.spellId, "warning")
+	self:Message("summon_stealthlings", "red", CL.spawned:format(args.spellName), args.spellId)
+	self:PlaySound("summon_stealthlings", "warning")
 end
 
 function mod:OozingCarcass(args)


### PR DESCRIPTION
This adds https://www.wowhead.com/spell=328400/stealthlings

Stealthlings need revealing by a mobile class with AoE, and/or CC'ing e.g. with Ursols Vortex or Binding Shot, so I think they're worth adding to LittleWigs for sure.

Untested, but ID is per my logs, and it's the same implementation as Enveloping Webbing.

I wasn't sure about the color and sound. I went with red and long, since Enveloping Webbing already uses alarm.