### PR TITLE
Shadowlands/TazaveshTheVeiledMarket/Trash: prevent out of combat alerts

### DIFF
--- a/Shadowlands/TazaveshTheVeiledMarket/Trash.lua
+++ b/Shadowlands/TazaveshTheVeiledMarket/Trash.lua
@@ -392,8 +392,11 @@ end
 -- Support Officer
 function mod:RefractionShieldApplied(args)
 	if not self:Player(args.destFlags) then
-		self:Message(args.spellId, "yellow", CL.on:format(args.spellName, args.destName))
-		self:PlaySound(args.spellId, "warning")
+		local unit = self:GetUnitIdByGUID(args.sourceGUID)
+		if unit and UnitAffectingCombat(unit) then
+			self:Message(args.spellId, "yellow", CL.on:format(args.spellName, args.destName))
+			self:PlaySound(args.spellId, "warning")
+		end
 	end
 end
 function mod:HardLightBarrier(args)


### PR DESCRIPTION
Refraction Shield can be applied out of combat, in particular it sometimes spams alerts when you teleport back and forth between the two entrances.