### PR TITLE
Shadowlands/Plaguefall/Trash: Scope dispels, remove broken Withering Filth target detection

### DIFF
--- a/Shadowlands/Plaguefall/Options/Colors.lua
+++ b/Shadowlands/Plaguefall/Options/Colors.lua
@@ -32,7 +32,7 @@ BigWigs:AddColors("Plaguefall Trash", {
 	[318949] = "red",
 	[320512] = {"blue","yellow"},
 	[320517] = "yellow",
-	[321935] = {"blue","red","yellow"},
+	[321935] = "red",
 	[323572] = "red",
 	[327233] = "red",
 	[327515] = {"blue","yellow"},

--- a/Shadowlands/Plaguefall/Options/Sounds.lua
+++ b/Shadowlands/Plaguefall/Options/Sounds.lua
@@ -31,7 +31,7 @@ BigWigs:AddSounds("Plaguefall Trash", {
 	[318949] = "alarm",
 	[320512] = "alert",
 	[320517] = "alert",
-	[321935] = {"alarm","info"},
+	[321935] = "alarm",
 	[323572] = "alarm",
 	[327233] = "alarm",
 	[327515] = "alert",

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -217,7 +217,7 @@ function mod:GrippingInfection(args)
 end
 
 function mod:GrippingInfectionApplied(args)
-	if self:Dispeller("disease", nil, args.spellId) then
+	if self:Dispeller("disease", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) then
 		self:TargetMessage(args.spellId, "yellow", args.destName)
 		self:PlaySound(args.spellId, "info", nil, args.destName)
 	end

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -78,7 +78,7 @@ function mod:GetOptions()
 		-- Plaguebinder
 		{328180, "DISPEL"}, -- Gripping Infection
 		-- Congealed Slime
-		{321935, "SAY"}, -- Withering Filth
+		321935, -- Withering Filth
 		-- Defender of Many Eyes
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
@@ -223,20 +223,9 @@ function mod:GrippingInfectionApplied(args)
 	end
 end
 
-do
-	local function printTarget(self, name, guid)
-		local isOnMe = self:Me(guid)
-		self:TargetMessage(321935, isOnMe and "red" or "yellow", name)
-		self:PlaySound(321935, isOnMe and "alarm" or "info", nil, name)
-		if isOnMe then
-			self:Say(321935)
-		end
-	end
-
-	function mod:WitheringFilth(args)
-		-- XXX check if the mob actually changes target
-		self:GetUnitTarget(printTarget, 0.6, args.sourceGUID)
-	end
+function mod:WitheringFilth(args)
+	self:Message(args.spellId, "red")
+	self:PlaySound(args.spellId, "alarm")
 end
 
 do

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -224,6 +224,8 @@ function mod:GrippingInfectionApplied(args)
 end
 
 function mod:WitheringFilth(args)
+	-- This ability has been bugged since 9.0, currently it seems to put the targeting circle on the player
+	-- at the top of the threat table but then it actually leap to the closest target at the end of the cast.
 	self:Message(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
 end

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -225,7 +225,7 @@ end
 
 function mod:WitheringFilth(args)
 	-- This ability has been bugged since 9.0, currently it seems to put the targeting circle on the player
-	-- at the top of the threat table but then it actually leap to the closest target at the end of the cast.
+	-- at the top of the threat table but then it actually leaps to the closest target at the end of the cast.
 	self:Message(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
 end


### PR DESCRIPTION
- Gripping Infection can also be dispelled by movement dispellers. (Fun fact, all movement dispellers are also disease dispellers until Dragonflight at least).
- Withering Filth has been bugged since 9.0 and puts a targeting circle on the tank but then leaps to the closest player instead, making both the Blizzard graphic and the LittleWigs say unreliable.