### PR TITLE
Shadowlands/SanguineDepths/Trash: Restrictions for Barbed Shackles warning

### DIFF
--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -168,8 +168,10 @@ function mod:BarbedShackles(args)
 end
 
 function mod:BarbedShacklesApplied(args)
-	self:TargetMessage(335305, "yellow", args.destName)
-	self:PlaySound(335305, "alert", nil, args.destName)
+	if self:Dispeller("movement") or self:Me(args.destGUID) then
+		self:TargetMessage(335305, "yellow", args.destName)
+		self:PlaySound(335305, "alert", nil, args.destName)
+	end
 end
 
 function mod:CrushingStrike(args)

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -168,7 +168,7 @@ function mod:BarbedShackles(args)
 end
 
 function mod:BarbedShacklesApplied(args)
-	if self:Dispeller("movement") or self:Me(args.destGUID) then
+	if self:Dispeller("movement") or self:Me(args.destGUID) or self:Healer() then
 		self:TargetMessage(335305, "yellow", args.destName)
 		self:PlaySound(335305, "alert", nil, args.destName)
 	end


### PR DESCRIPTION
Barbed Shackles application scoped to movement dispellers, self, and healers.