### PR TITLE
Shadowlands/Plaguefall/Trash: Crushing Embrace, Vile Spit

### DIFF
--- a/Shadowlands/Plaguefall/Locales/deDE.lua
+++ b/Shadowlands/Plaguefall/Locales/deDE.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Verseuchter Rückenbrecher"
 	L.plaguebinder = "Seuchenbinder"
 	L.congealed_slime = "Geronnener Schleim"
+	L.slime_tentacle = "Schleimtentakel"
 	L.defender_of_many_eyes = "Verteidiger der vielzähligen Augen"
 	L.brood_ambusher = "Brutwegelagerer"
 	L.ickor_bileflesh = "Ickor Gallenfleisch"

--- a/Shadowlands/Plaguefall/Locales/esES.lua
+++ b/Shadowlands/Plaguefall/Locales/esES.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Partemédulas contagiado"
 	L.plaguebinder = "Vinculapestes"
 	L.congealed_slime = "Baba coagulada"
+	L.slime_tentacle = "Tentáculo de baba"
 	L.defender_of_many_eyes = "Defensor de muchos ojos"
 	L.brood_ambusher = "Emboscador de linaje"
 	L.ickor_bileflesh = "Ickor Carnebilis"

--- a/Shadowlands/Plaguefall/Locales/frFR.lua
+++ b/Shadowlands/Plaguefall/Locales/frFR.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Brise-échine chancreux"
 	L.plaguebinder = "Lieur de peste"
 	L.congealed_slime = "Gelée figée"
+	L.slime_tentacle = "Tentacule visqueux"
 	L.defender_of_many_eyes = "Défenseur aux innombrables yeux"
 	L.brood_ambusher = "Embusqué de la couvée"
 	L.ickor_bileflesh = "Ickor Aigrechair"

--- a/Shadowlands/Plaguefall/Locales/itIT.lua
+++ b/Shadowlands/Plaguefall/Locales/itIT.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Spezzaschiena Ammorbato"
 	L.plaguebinder = "Vincolapiaga"
 	L.congealed_slime = "Poltiglia Coagulata"
+	L.slime_tentacle = "Tentacolo di Poltiglia"
 	L.defender_of_many_eyes = "Difensore dai Molti Occhi"
 	L.brood_ambusher = "Aggressore della Stirpe"
 	L.ickor_bileflesh = "Ickor Carnebiliare"

--- a/Shadowlands/Plaguefall/Locales/koKR.lua
+++ b/Shadowlands/Plaguefall/Locales/koKR.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "역병 걸린 척추파괴자"
 	L.plaguebinder = "역병결속자"
 	L.congealed_slime = "응결된 점액"
+	L.slime_tentacle = "점액 촉수"
 	L.defender_of_many_eyes = "수많은 눈의 수호병"
 	L.brood_ambusher = "혈족 매복꾼"
 	L.ickor_bileflesh = "이코르 바일플래시"

--- a/Shadowlands/Plaguefall/Locales/ptBR.lua
+++ b/Shadowlands/Plaguefall/Locales/ptBR.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Quebra-espinhas Pestilento"
 	L.plaguebinder = "Atapeste"
 	L.congealed_slime = "Visgo Coagulado"
+	L.slime_tentacle = "Tentáculo de Visgo"
 	L.defender_of_many_eyes = "Defensora de Muitos Olhos"
 	L.brood_ambusher = "Emboscadora da Ninhada"
 	L.ickor_bileflesh = "Carnebílis Línfico"

--- a/Shadowlands/Plaguefall/Locales/ruRU.lua
+++ b/Shadowlands/Plaguefall/Locales/ruRU.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "Чумной спинолом"
 	L.plaguebinder = "Заклинатель чумы"
 	L.congealed_slime = "Сгусток слизи"
+	L.slime_tentacle = "Склизкое щупальце"
 	L.defender_of_many_eyes = "Защитник из многоокой рати"
 	L.brood_ambusher = "Таящийся паук"
 	L.ickor_bileflesh = "Икор Желчная Плоть"

--- a/Shadowlands/Plaguefall/Locales/zhCN.lua
+++ b/Shadowlands/Plaguefall/Locales/zhCN.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "凋零碎脊者"
 	L.plaguebinder = "魔药束缚者"
 	L.congealed_slime = "凝结软泥"
+	L.slime_tentacle = "软泥触须"
 	L.defender_of_many_eyes = "万眼防御者"
 	L.brood_ambusher = "巢群伏击者"
 	L.ickor_bileflesh = "艾柯尔·胆肉"

--- a/Shadowlands/Plaguefall/Locales/zhTW.lua
+++ b/Shadowlands/Plaguefall/Locales/zhTW.lua
@@ -10,6 +10,7 @@ if L then
 	L.blighted_spinebreaker = "荒蕪斷脊者"
 	L.plaguebinder = "瘟疫束縛者"
 	L.congealed_slime = "凝結軟泥怪"
+	L.slime_tentacle = "軟泥怪觸手"
 	L.defender_of_many_eyes = "多眼防衛者"
 	L.brood_ambusher = "育巢伏擊者"
 	L.ickor_bileflesh = "伊可‧膽肉"

--- a/Shadowlands/Plaguefall/Options/Colors.lua
+++ b/Shadowlands/Plaguefall/Options/Colors.lua
@@ -30,6 +30,7 @@ BigWigs:AddColors("Margrave Stradama", {
 
 BigWigs:AddColors("Plaguefall Trash", {
 	[318949] = "red",
+	[319898] = "red",
 	[320512] = {"blue","yellow"},
 	[320517] = "yellow",
 	[321935] = "red",

--- a/Shadowlands/Plaguefall/Options/Colors.lua
+++ b/Shadowlands/Plaguefall/Options/Colors.lua
@@ -42,6 +42,7 @@ BigWigs:AddColors("Plaguefall Trash", {
 	[328016] = "orange",
 	[328177] = "orange",
 	[328180] = {"blue","orange","yellow"},
+	[328429] = {"blue","yellow"},
 	[328475] = "red",
 	[329239] = "orange",
 	[330403] = "red",

--- a/Shadowlands/Plaguefall/Options/Sounds.lua
+++ b/Shadowlands/Plaguefall/Options/Sounds.lua
@@ -29,6 +29,7 @@ BigWigs:AddSounds("Margrave Stradama", {
 
 BigWigs:AddSounds("Plaguefall Trash", {
 	[318949] = "alarm",
+	[319898] = "alarm",
 	[320512] = "alert",
 	[320517] = "alert",
 	[321935] = "alarm",

--- a/Shadowlands/Plaguefall/Options/Sounds.lua
+++ b/Shadowlands/Plaguefall/Options/Sounds.lua
@@ -41,6 +41,7 @@ BigWigs:AddSounds("Plaguefall Trash", {
 	[328016] = "alert",
 	[328177] = "alert",
 	[328180] = {"alert","info"},
+	[328429] = "alert",
 	[328475] = "alarm",
 	[329239] = "alert",
 	[330403] = "alarm",

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -254,7 +254,8 @@ do
 
 	function mod:CrushingEmbrace(args)
 		sourceMobId = self:MobId(args.sourceGUID)
-		self:GetUnitTarget(printTarget, 0.2, args.sourceGUID)
+		-- TODO test target detection, but i think it should work
+		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
 	end
 end
 

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -84,6 +84,7 @@ function mod:GetOptions()
 		321935, -- Withering Filth
 		-- Slime Tentacle
 		{328429, "SAY"}, -- Crushing Embrace
+		319898, -- Vile Spit
 		-- Defender of Many Eyes
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
@@ -135,6 +136,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "GrippingInfectionApplied", 328180)
 	self:Log("SPELL_CAST_START", "WitheringFilth", 321935)
 	self:Log("SPELL_CAST_START", "CrushingEmbrace", 328429)
+	self:Log("SPELL_CAST_START", "VileSpit", 319898)
 	self:Log("SPELL_CAST_SUCCESS", "BulwarkOfMaldraxxus", 336451)
 	self:Log("SPELL_CAST_START", "EnvelopingWebbing", 328475)
 	self:Log("SPELL_CAST_SUCCESS", "Stealthlings", 328400)
@@ -256,6 +258,14 @@ do
 		sourceMobId = self:MobId(args.sourceGUID)
 		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
 	end
+end
+
+function mod:VileSpit(args)
+	if self:Friendly(args.sourceFlags) then -- these NPCs can be mind-controlled by priests
+		return
+	end
+	self:Message(args.spellId, "red")
+	self:PlaySound(args.spellId, "alarm")
 end
 
 do

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -240,12 +240,8 @@ function mod:WitheringFilth(args)
 end
 
 do
-	local sourceMobId = nil
-
-	local function printTarget(self, name, guid)
-		-- depending on source NPC id it is either CCable or only can be stopped by movement dispellers
-		local movementDispelOnly = sourceMobId == 168907
-		if not movementDispelOnly or self:Dispeller("movement") or self:Healer() or self:Me(guid) then
+	local function printTargetMovementDispelOnly(self, name, guid)
+		if self:Dispeller("movement") or self:Healer() or self:Me(guid) then
 			self:TargetMessage(328429, "yellow", name)
 			self:PlaySound(328429, "alert", nil, name)
 			if self:Me(guid) then
@@ -254,9 +250,23 @@ do
 		end
 	end
 
+	local function printTarget(self, name, guid)
+		self:TargetMessage(328429, "yellow", name)
+		self:PlaySound(328429, "alert", nil, name)
+		if self:Me(guid) then
+			self:Say(328429)
+		end
+	end
+
 	function mod:CrushingEmbrace(args)
-		sourceMobId = self:MobId(args.sourceGUID)
-		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
+		-- depending on source NPC id it is either CCable or only can be stopped by movement dispellers
+		local movementDispelOnly = self:MobId(args.sourceGUID) == 168907
+
+		if movementDispelOnly then
+			self:GetUnitTarget(printTargetMovementDispelOnly, 0.5, args.sourceGUID)
+		else
+			self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
+		end
 	end
 end
 

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -254,7 +254,6 @@ do
 
 	function mod:CrushingEmbrace(args)
 		sourceMobId = self:MobId(args.sourceGUID)
-		-- TODO test target detection, but i think it should work
 		self:GetUnitTarget(printTarget, 0.5, args.sourceGUID)
 	end
 end

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -83,7 +83,7 @@ function mod:GetOptions()
 		-- Congealed Slime
 		321935, -- Withering Filth
 		-- Slime Tentacle
-		328429, -- Crushing Embrace
+		{328429, "SAY"}, -- Crushing Embrace
 		-- Defender of Many Eyes
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
@@ -237,11 +237,25 @@ function mod:WitheringFilth(args)
 	self:PlaySound(args.spellId, "alarm")
 end
 
-function mod:CrushingEmbrace(args)
-	-- TODO get target, it's a 1 second cast
-	-- depending on source NPC id it is either CCable or only movement dispellers
-	self:Message(args.spellId, "red")
-	self:PlaySound(args.spellId, "warning")
+do
+	local sourceMobId = nil
+
+	local function printTarget(self, name, guid)
+		-- depending on source NPC id it is either CCable or only can be stopped by movement dispellers
+		local movementDispelOnly = sourceMobId == 168907
+		if not movementDispelOnly or self:Dispeller("movement") or self:Healer() or self:Me(guid) then
+			self:TargetMessage(328429, "yellow", name)
+			self:PlaySound(328429, "alert", nil, name)
+			if self:Me(guid) then
+				self:Say(328429)
+			end
+		end
+	end
+
+	function mod:CrushingEmbrace(args)
+		sourceMobId = self:MobId(args.sourceGUID)
+		self:GetUnitTarget(printTarget, 0.2, args.sourceGUID)
+	end
 end
 
 do

--- a/Shadowlands/Plaguefall/Trash.lua
+++ b/Shadowlands/Plaguefall/Trash.lua
@@ -17,6 +17,8 @@ mod:RegisterEnableMob(
 	163894, -- Blighted Spinebreaker
 	168627, -- Plaguebinder
 	164707, -- Congealed Slime
+	168022, -- Slime Tentacle
+	168907, -- Slime Tentacle (CC immune version)
 	163862, -- Defender of Many Eyes
 	164737, -- Brood Ambusher
 	169861, -- Ickor Bileflesh
@@ -40,6 +42,7 @@ if L then
 	L.blighted_spinebreaker = "Blighted Spinebreaker"
 	L.plaguebinder = "Plaguebinder"
 	L.congealed_slime = "Congealed Slime"
+	L.slime_tentacle = "Slime Tentacle"
 	L.defender_of_many_eyes = "Defender of Many Eyes"
 	L.brood_ambusher = "Brood Ambusher"
 	L.ickor_bileflesh = "Ickor Bileflesh"
@@ -79,6 +82,8 @@ function mod:GetOptions()
 		{328180, "DISPEL"}, -- Gripping Infection
 		-- Congealed Slime
 		321935, -- Withering Filth
+		-- Slime Tentacle
+		328429, -- Crushing Embrace
 		-- Defender of Many Eyes
 		336451, -- Bulwark of Maldraxxus
 		-- Brood Ambusher
@@ -103,6 +108,7 @@ function mod:GetOptions()
 		[318949] = L.blighted_spinebreaker,
 		[328180] = L.plaguebinder,
 		[321935] = L.congealed_slime,
+		[328429] = L.slime_tentacle,
 		[336451] = L.defender_of_many_eyes,
 		[328475] = L.brood_ambusher,
 		[330786] = L.ickor_bileflesh,
@@ -128,6 +134,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "GrippingInfection", 328180)
 	self:Log("SPELL_AURA_APPLIED", "GrippingInfectionApplied", 328180)
 	self:Log("SPELL_CAST_START", "WitheringFilth", 321935)
+	self:Log("SPELL_CAST_START", "CrushingEmbrace", 328429)
 	self:Log("SPELL_CAST_SUCCESS", "BulwarkOfMaldraxxus", 336451)
 	self:Log("SPELL_CAST_START", "EnvelopingWebbing", 328475)
 	self:Log("SPELL_CAST_SUCCESS", "Stealthlings", 328400)
@@ -228,6 +235,13 @@ function mod:WitheringFilth(args)
 	-- at the top of the threat table but then it actually leaps to the closest target at the end of the cast.
 	self:Message(args.spellId, "red")
 	self:PlaySound(args.spellId, "alarm")
+end
+
+function mod:CrushingEmbrace(args)
+	-- TODO get target, it's a 1 second cast
+	-- depending on source NPC id it is either CCable or only movement dispellers
+	self:Message(args.spellId, "red")
+	self:PlaySound(args.spellId, "warning")
 end
 
 do


### PR DESCRIPTION
Show crushing embrace alert for healers and the target.

Depending on which version of Slime Tentacle is the caster, additionally show an alert for whoever can stop the cast.