### PR TITLE
Shadowlands/TheaterOfPain: Gorechop respawn timer, bug fixes

### DIFF
--- a/Shadowlands/TheaterOfPain/Gorechop.lua
+++ b/Shadowlands/TheaterOfPain/Gorechop.lua
@@ -45,17 +45,15 @@ end
 
 do
 	local function warnMeatHooks()
-		if mod:IsEngaged() then
-			mod:Message(322795, "orange")
-			mod:PlaySound(322795, "alert")
-			mod:Bar(322795, 20.6)
-		end
+		mod:Message(322795, "orange")
+		mod:PlaySound(322795, "alert")
+		mod:Bar(322795, 20.6)
 	end
 
 	function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		-- The boss casts Meat Hooks 5 seconds before anything actually happens
 		if spellId == 322795 then -- Meat Hooks
-			self:SimpleTimer(warnMeatHooks, 5)
+			self:ScheduleTimer(warnMeatHooks, 5)
 		end
 	end
 end

--- a/Shadowlands/TheaterOfPain/Gorechop.lua
+++ b/Shadowlands/TheaterOfPain/Gorechop.lua
@@ -34,7 +34,9 @@ end
 function mod:OnEngage()
 	self:Bar(322795, 10.8) -- Meat Hooks, 5.8 sec until the first cast
 	self:Bar(323515, 7) -- Hateful Strike
-	self:Bar(318406, 13.1) -- Tenderizing Smash
+	if self:Mythic() then
+		self:Bar(318406, 13.1) -- Tenderizing Smash
+	end
 end
 
 --------------------------------------------------------------------------------

--- a/Shadowlands/TheaterOfPain/Gorechop.lua
+++ b/Shadowlands/TheaterOfPain/Gorechop.lua
@@ -45,9 +45,11 @@ end
 
 do
 	local function warnMeatHooks()
-		mod:Message(322795, "orange")
-		mod:PlaySound(322795, "alert")
-		mod:Bar(322795, 20.6)
+		if mod:IsEngaged() then
+			mod:Message(322795, "orange")
+			mod:PlaySound(322795, "alert")
+			mod:Bar(322795, 20.6)
+		end
 	end
 
 	function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)

--- a/Shadowlands/TheaterOfPain/Gorechop.lua
+++ b/Shadowlands/TheaterOfPain/Gorechop.lua
@@ -1,4 +1,3 @@
-
 --------------------------------------------------------------------------------
 -- Module Declaration
 --
@@ -6,8 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Gorechop", 2293, 2401)
 if not mod then return end
 mod:RegisterEnableMob(162317)
-mod.engageId = 2365
---mod.respawnTime = 30
+mod:SetEncounterID(2365)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Initialization

--- a/Shadowlands/TheaterOfPain/Options/Sounds.lua
+++ b/Shadowlands/TheaterOfPain/Options/Sounds.lua
@@ -57,7 +57,7 @@ BigWigs:AddSounds("Theater Of Pain Trash", {
 	[331237] = "info",
 	[331275] = "info",
 	[332708] = "alert",
-	[332836] = {"alert","warning"},
+	[332836] = "alert",
 	[333241] = "warning",
 	[333294] = "alarm",
 	[333708] = "alert",

--- a/Shadowlands/TheaterOfPain/Trash.lua
+++ b/Shadowlands/TheaterOfPain/Trash.lua
@@ -1,4 +1,3 @@
-
 --------------------------------------------------------------------------------
 -- Module Declaration
 --
@@ -250,7 +249,9 @@ do
 		if self:Friendly(args.sourceFlags) then -- these NPCs can be mind-controlled by DKs
 			return
 		end
-		self:GetUnitTarget(printTarget, 0.2, args.sourceGUID)
+		if not self:Tank() then
+			self:GetUnitTarget(printTarget, 0.2, args.sourceGUID)
+		end
 	end
 end
 

--- a/Shadowlands/TheaterOfPain/Trash.lua
+++ b/Shadowlands/TheaterOfPain/Trash.lua
@@ -239,10 +239,9 @@ function mod:DevourFlesh(args)
 end
 do
 	local function printTarget(self, name, guid)
-		local onMe = self:Me(guid)
-		if onMe or self:Healer() then
+		if self:Me(guid) or self:Healer() then
 			self:TargetMessage(332836, "red", name)
-			self:PlaySound(332836, onMe and "warning" or "alert", nil, name)
+			self:PlaySound(332836, "alert", nil, name)
 		end
 	end
 	function mod:Chop(args)


### PR DESCRIPTION
- 30s respawn
- Tenderizing Smash is Mythic-only, don't show initial CD bar in other difficulties.
- Meat Hook timer shouldn't show up if the encounter has ended
- Gorechop Trash: Tanks don't care if Chop is on them