### PR TITLE
Shadowlands/TheaterOfPain/Kultharok: Respawn timer, fix Spectral Reach alert

### DIFF
--- a/Shadowlands/TheaterOfPain/Kultharok.lua
+++ b/Shadowlands/TheaterOfPain/Kultharok.lua
@@ -32,6 +32,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	self:Bar(319626, 3.3) -- Phantasmal Parasite
 	self:Bar(319521, 15.8) -- Draw Soul
 end
 

--- a/Shadowlands/TheaterOfPain/Kultharok.lua
+++ b/Shadowlands/TheaterOfPain/Kultharok.lua
@@ -17,7 +17,7 @@ function mod:GetOptions()
 		{319521, "ME_ONLY"}, -- Draw Soul
 		{319637, "ME_ONLY"}, -- Reclaimed Soul
 		{319626, "SAY", "FLASH"}, -- Phantasmal Parasite
-		{319669, "TANK"}, -- Spectral Reach
+		319669, -- Spectral Reach
 	}
 end
 
@@ -28,7 +28,7 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED_DOSE", "ReclaimedSoulApplied", 319637)
 	self:Log("SPELL_CAST_SUCCESS", "PhantasmalParasite", 319626)
 	self:Log("SPELL_AURA_APPLIED", "PhantasmalParasiteApplied", 319626)
-	self:Log("SPELL_CAST_SUCCESS", "SpectralReach", 319669)
+	self:Log("SPELL_CAST_START", "SpectralReach", 319669)
 end
 
 function mod:OnEngage()

--- a/Shadowlands/TheaterOfPain/Kultharok.lua
+++ b/Shadowlands/TheaterOfPain/Kultharok.lua
@@ -1,4 +1,3 @@
-
 --------------------------------------------------------------------------------
 -- Module Declaration
 --
@@ -6,8 +5,8 @@
 local mod, CL = BigWigs:NewBoss("Kul'tharok", 2293, 2389)
 if not mod then return end
 mod:RegisterEnableMob(162309)
-mod.engageId = 2364
---mod.respawnTime = 30
+mod:SetEncounterID(2364)
+mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
 -- Initialization


### PR DESCRIPTION
- 30s respawn
- Spectral Reach is interruptible (and gets chain-cast if the tank is out of range) so alert everyone on cast start instead of tank-only on cast end