### PR TITLE
Shadowlands/SanguineDepths/Trash: Sap Lifeblood, scope abilities

### DIFF
--- a/Shadowlands/SanguineDepths/Locales/deDE.lua
+++ b/Shadowlands/SanguineDepths/Locales/deDE.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Majestätischer Nebeltänzer"
 	L.research_scribe = "Forschungsschreiberin"
 	L.wicked_oppressor = "Tückische Unterdrückerin"
+	L.ravenous_dreadbat = "Unersättliche Fleddermaus"
 end

--- a/Shadowlands/SanguineDepths/Locales/esES.lua
+++ b/Shadowlands/SanguineDepths/Locales/esES.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Bailarín de la niebla regio"
 	L.research_scribe = "Escriba de investigación"
 	L.wicked_oppressor = "Opresora perversa"
+	L.ravenous_dreadbat = "Murciélago aterrador voraz"
 end

--- a/Shadowlands/SanguineDepths/Locales/frFR.lua
+++ b/Shadowlands/SanguineDepths/Locales/frFR.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Danse-brume régalien"
 	L.research_scribe = "Scribe chercheuse"
 	L.wicked_oppressor = "Oppresseuse malfaisante"
+	L.ravenous_dreadbat = "Chiropteffroi vorace"
 end

--- a/Shadowlands/SanguineDepths/Locales/itIT.lua
+++ b/Shadowlands/SanguineDepths/Locales/itIT.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Danzanebbia Regale"
 	L.research_scribe = "Scriba Ricercatrice"
 	L.wicked_oppressor = "Oppressora Malvagia"
+	L.ravenous_dreadbat = "Chirorrore Vorace"
 end

--- a/Shadowlands/SanguineDepths/Locales/koKR.lua
+++ b/Shadowlands/SanguineDepths/Locales/koKR.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "제왕의 안개춤꾼"
 	L.research_scribe = "연구 필경사"
 	L.wicked_oppressor = "사악한 탄압자"
+	L.ravenous_dreadbat = "포악한 공포박쥐"
 end

--- a/Shadowlands/SanguineDepths/Locales/ptBR.lua
+++ b/Shadowlands/SanguineDepths/Locales/ptBR.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Dançarino da Névoa Régio"
 	L.research_scribe = "Escriba Pesquisadora"
 	L.wicked_oppressor = "Opressora Perversa"
+	L.ravenous_dreadbat = "Deimorcego Voraz"
 end

--- a/Shadowlands/SanguineDepths/Locales/ruRU.lua
+++ b/Shadowlands/SanguineDepths/Locales/ruRU.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "Благородный туманный танцор"
 	L.research_scribe = "Писец-исследовательница"
 	L.wicked_oppressor = "Зловещая подавительница"
+	L.ravenous_dreadbat = "Прожорливый жуткий нетопырь"
 end

--- a/Shadowlands/SanguineDepths/Locales/zhCN.lua
+++ b/Shadowlands/SanguineDepths/Locales/zhCN.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "皇家舞雾者"
 	L.research_scribe = "研究铭文师"
 	L.wicked_oppressor = "邪恶的镇压者"
+	L.ravenous_dreadbat = "贪婪的恐惧蝠"
 end

--- a/Shadowlands/SanguineDepths/Locales/zhTW.lua
+++ b/Shadowlands/SanguineDepths/Locales/zhTW.lua
@@ -12,4 +12,5 @@ if L then
 	L.regal_mistdancer = "皇家霧舞者"
 	L.research_scribe = "研究紀錄者"
 	L.wicked_oppressor = "邪惡壓迫者"
+	--L.ravenous_dreadbat = "Ravenous Dreadbat"
 end

--- a/Shadowlands/SanguineDepths/Locales/zhTW.lua
+++ b/Shadowlands/SanguineDepths/Locales/zhTW.lua
@@ -12,5 +12,5 @@ if L then
 	L.regal_mistdancer = "皇家霧舞者"
 	L.research_scribe = "研究紀錄者"
 	L.wicked_oppressor = "邪惡壓迫者"
-	--L.ravenous_dreadbat = "Ravenous Dreadbat"
+	L.ravenous_dreadbat = "飢餓的懼蝠"
 end

--- a/Shadowlands/SanguineDepths/Options/Colors.lua
+++ b/Shadowlands/SanguineDepths/Options/Colors.lua
@@ -29,6 +29,7 @@ BigWigs:AddColors("General Kaal", {
 
 BigWigs:AddColors("Sanguine Depths Trash", {
 	[320991] = "red",
+	[321105] = "yellow",
 	[321178] = "red",
 	[322429] = "orange",
 	[322433] = {"orange","yellow"},

--- a/Shadowlands/SanguineDepths/Options/Sounds.lua
+++ b/Shadowlands/SanguineDepths/Options/Sounds.lua
@@ -29,6 +29,7 @@ BigWigs:AddSounds("General Kaal", {
 
 BigWigs:AddSounds("Sanguine Depths Trash", {
 	[320991] = "alarm",
+	[321105] = "alert",
 	[321178] = "alarm",
 	[322429] = "alert",
 	[322433] = {"alert","warning"},

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -51,7 +51,7 @@ function mod:GetOptions()
 		341321, -- Summon Anima Collector Stalker
 		-- Chamber Sentinel
 		328170, -- Craggy Fracture
-		322429, -- Severing Slice
+		{322429, "TANK_HEALER"}, -- Severing Slice
 		322433, -- Stoneskin
 		-- Depths Warden
 		335305, -- Barbed Shackles

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -67,7 +67,7 @@ function mod:GetOptions()
 		334329, -- Sweeping Slash
 		{334326, "TANK_HEALER"}, -- Bludgeoning Bash
 		-- Insatiable Brute
-		{321178, "TANK_HEALER"}, -- Slam
+		{321178, "TANK"}, -- Slam
 		334918, -- Umbral Crash
 		-- Regal Mistdancer
 		320991, -- Echoing Thrust

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -149,8 +149,14 @@ function mod:SeveringSlice(args)
 end
 
 function mod:Stoneskin(args)
-	self:Message(args.spellId, "orange", CL.casting:format(args.spellName))
-	self:PlaySound(args.spellId, "alert")
+	local canInterrupt, interruptReady = self:Interrupter()
+
+	if canInterrupt then
+		self:Message(args.spellId, "orange", CL.casting:format(args.spellName))
+		if interruptReady then
+			self:PlaySound(args.spellId, "alert")
+		end
+	end
 end
 
 function mod:StoneskinApplied(args)

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -1,4 +1,3 @@
-
 --------------------------------------------------------------------------------
 -- Module Declaration
 --
@@ -19,7 +18,8 @@ mod:RegisterEnableMob(
 	166396, -- Noble Skirmisher
 	162038, -- Regal Mistdancer
 	171805, -- Research Scribe
-	162039 -- Wicked Oppressor
+	162039, -- Wicked Oppressor
+	168591 -- Ravenous Dreadbat
 )
 
 --------------------------------------------------------------------------------
@@ -39,6 +39,7 @@ if L then
 	L.regal_mistdancer = "Regal Mistdancer"
 	L.research_scribe = "Research Scribe"
 	L.wicked_oppressor = "Wicked Oppressor"
+	L.ravenous_dreadbat = "Ravenous Dreadbat"
 end
 
 --------------------------------------------------------------------------------
@@ -75,6 +76,8 @@ function mod:GetOptions()
 		334377, -- Explosive Vellum
 		-- Wicked Oppressor
 		{326836, "DISPEL"}, -- Curse of Suppression
+		-- Ravenous Dreadbat
+		321105, -- Sap Lifeblood
 	}, {
 		[341321] = L.anima_collector,
 		[328170] = L.chamber_sentinel,
@@ -87,6 +90,7 @@ function mod:GetOptions()
 		[320991] = L.regal_mistdancer,
 		[334377] = L.research_scribe,
 		[326836] = L.wicked_oppressor,
+		[321105] = L.ravenous_dreadbat,
 	}
 end
 
@@ -123,6 +127,8 @@ function mod:OnBossEnable()
 		-- Wicked Oppressor
 		self:Log("SPELL_CAST_START", "CurseOfSuppression", 326836) -- Curse of Suppression
 		self:Log("SPELL_AURA_APPLIED", "CurseOfSuppressionApplied", 326836) -- Curse of Suppression
+		-- Ravenous Dreadbat
+		self:Log("SPELL_CAST_START", "SapLifeblood", 321105) -- Sap Lifeblood
 end
 
 --------------------------------------------------------------------------------
@@ -296,4 +302,11 @@ function mod:CurseOfSuppressionApplied(args)
 		self:TargetMessage(args.spellId, "red", args.destName)
 		self:PlaySound(args.spellId, "warning", nil, args.destName)
 	end
+end
+
+-- Ravenous Dreadbat
+
+function mod:SapLifeblood(args)
+	self:Message(args.spellId, "yellow", CL.casting:format(args.spellName))
+	self:PlaySound(args.spellId, "alert")
 end

--- a/Shadowlands/SanguineDepths/Trash.lua
+++ b/Shadowlands/SanguineDepths/Trash.lua
@@ -154,7 +154,7 @@ function mod:Stoneskin(args)
 end
 
 function mod:StoneskinApplied(args)
-	if not self:Player(args.destFlags) then
+	if not self:Player(args.destFlags) and self:Dispeller("magic", true) then
 		self:Message(args.spellId, "yellow", CL.on:format(args.spellName, args.destName))
 		self:PlaySound(args.spellId, "warning")
 	end


### PR DESCRIPTION
Ravenous Dreadbat
- Track Sap Lifeblood (stunnable/interruptible lifesteal)

Chamber Sentinel
- Only alert on Stoneskin cast for interrupters
- Only alert on Stoneskin application for offensive magic dispellers
- Severing Slice to tank/healer only (was everyone)

Insatiable Brute
- Slam to tank only (was tank/healer)