### PR TITLE
 Shadowlands/MistsOfTirnaScithe/IngraMaloch: Fix wrath timer

### DIFF
--- a/Shadowlands/MistsOfTirnaScithe/IngraMaloch.lua
+++ b/Shadowlands/MistsOfTirnaScithe/IngraMaloch.lua
@@ -92,7 +92,7 @@ end
 function mod:DromansWrathApplied(args)
 	self:StopBar(323137) -- Bewildering Pollen
 	self:StopBar(323177) -- Tears of the Forest
-	self:Bar(args.spellId, 12)
+	self:Bar(args.spellId, 15)
 end
 
 function mod:DromansWrathRemoved(args)


### PR DESCRIPTION
According to the August 9, 2021,
"The duration of Droman's Wrath has been increased to 15 seconds (was 12 seconds)"
So a small fix to the bar duration was required.