### PR TITLE
BfA/KingsRest/Trash: Tweak periodic damage logic

### DIFF
--- a/BfA/KingsRest/Trash.lua
+++ b/BfA/KingsRest/Trash.lua
@@ -616,7 +616,11 @@ end
 function mod:PeriodicDamage(args)
 	if self:Me(args.destGUID) then
 		if isThrottled(args.spellId, 1.5) then return end
-		self:PersonalMessage(args.spellId, args.spellId == 270503 and "near" or "underyou")
+		if args.spellId == 270503 then
+			self:PersonalMessage(args.spellId, "near")
+		else
+			self:PersonalMessage(args.spellId, "underyou")
+		end
 		self:PlaySound(args.spellId, "alert")
 	end
 end


### PR DESCRIPTION
Fixes:

`BfA/KingsRest/Trash.lua:619: Invalid localeString! func=mod:PeriodicDamage, key=args.spellId, localeString=args.spellId == 270503 and "near" or "underyou", text=nil`