### PR TITLE
Legion/Karazhan/OperaWestfall: Dashing Flame Gale timer update

### DIFF
--- a/Legion/Karazhan/OperaWestfall.lua
+++ b/Legion/Karazhan/OperaWestfall.lua
@@ -55,7 +55,6 @@ end
 function mod:ENCOUNTER_END(_, engageId, _, _, _, status)
 	if engageId == 1957 then
 		if status == 0 then
-			self:Wipe()
 			-- force a respawn timer
 			self:SendMessage("BigWigs_EncounterEnd", self, engageId, self.displayName, self:Difficulty(), 5, status)
 		else

--- a/Legion/Karazhan/OperaWestfall.lua
+++ b/Legion/Karazhan/OperaWestfall.lua
@@ -44,7 +44,7 @@ end
 function mod:OnEngage()
 	self:SetStage(1)
 	self:Bar(227568, 8.5) -- Burning Leg Sweep
-	self:Bar(227453, 6.1) -- Dashing Flame Gale
+	self:Bar(227453, 6.1) -- Dashing Flame Gale TODO confirm, changed by hotfix
 	self:RegisterEvent("INSTANCE_ENCOUNTER_ENGAGE_UNIT")
 end
 
@@ -78,7 +78,7 @@ function mod:INSTANCE_ENCOUNTER_ENGAGE_UNIT()
 		self:Message("stages", "cyan", CL.stage:format(3), false)
 		self:PlaySound("stages", "long")
 		self:Bar(227568, 8) -- Burning Leg Sweep
-		self:Bar(227453, 19.7) -- Dashing Flame Gale
+		self:Bar(227453, 19.7) -- Dashing Flame Gale TODO confirm, changed by hotfix
 	end
 end
 
@@ -86,7 +86,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 227449 then -- Dashing Flame Gale
 		self:Message(227453, "orange")
 		self:PlaySound(227453, "alert")
-		self:CDBar(227453, 21.8)
+		self:CDBar(227453, 36.8) -- TODO confirm, changed by hotfix
 	end
 end
 


### PR DESCRIPTION
Sep 1 hotfix notes:

> Increased the cooldown on Toe Knee's Dashing Flame Gale to 35 seconds (was 20 seconds).