### PR TITLE
WoD/IronDocks/Trash: Remove unnecessary Flaming Arrows alert

### DIFF
--- a/WoD/IronDocks/Options/Colors.lua
+++ b/WoD/IronDocks/Options/Colors.lua
@@ -44,7 +44,7 @@ BigWigs:AddColors("Iron Docks Trash", {
 	[172982] = "red",
 	[173105] = {"blue","yellow"},
 	[173135] = "yellow",
-	[173148] = {"blue","yellow"},
+	[173148] = "blue",
 	[173324] = "blue",
 	[173384] = "red",
 	[173480] = {"blue","orange"},

--- a/WoD/IronDocks/Options/Sounds.lua
+++ b/WoD/IronDocks/Options/Sounds.lua
@@ -44,7 +44,7 @@ BigWigs:AddSounds("Iron Docks Trash", {
 	[172982] = "alarm",
 	[173105] = {"alarm","underyou"},
 	[173135] = "alert",
-	[173148] = {"alert","underyou"},
+	[173148] = "underyou",
 	[173324] = "underyou",
 	[173384] = "alarm",
 	[173480] = {"alert","underyou"},

--- a/WoD/IronDocks/Trash.lua
+++ b/WoD/IronDocks/Trash.lua
@@ -95,7 +95,6 @@ function mod:OnBossEnable()
 	self:Log("SPELL_AURA_APPLIED", "BurningArrowsDamage", 164632)
 	self:Log("SPELL_PERIODIC_DAMAGE", "BurningArrowsDamage", 164632)
 	self:Log("SPELL_MISSED", "BurningArrowsDamage", 164632)
-	self:Log("SPELL_CAST_START", "FlamingArrows", 173148)
 	self:Log("SPELL_AURA_APPLIED", "FlamingArrowsDamage", 173149)
 	self:Log("SPELL_PERIODIC_DAMAGE", "FlamingArrowsDamage", 173149)
 	self:Log("SPELL_MISSED", "FlamingArrowsDamage", 173149)
@@ -170,11 +169,6 @@ do
 			end
 		end
 	end
-end
-
-function mod:FlamingArrows(args)
-	self:Message(args.spellId, "yellow")
-	self:PlaySound(args.spellId, "alert")
 end
 
 do


### PR DESCRIPTION
This ability is instantly recast if stunned.