### PR TITLE
Dragonflight/RubyLifePools/MelidrussaChillworn: Primal Chill updates

### DIFF
--- a/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
+++ b/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
@@ -65,15 +65,14 @@ do
 	local prev = 0
 	function mod:PrimalChillApplied(args)
 		local amount = args.amount
-		-- TODO build 45632 this ability is presumably bugged and cannot be dispelled by movement-dispelling effects
-		if amount >= 3 and amount < 5 and (self:Dispeller("magic", nil, args.spellId) --[[or self:Dispeller("movement", nil, args.spellId)]] or self:Me(args.destGUID)) then
+		if amount >= 5 and amount < 10 and (self:Dispeller("magic", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) or self:Me(args.destGUID)) then
 			-- this can sometimes apply rapidly or to more than one person, so add a short throttle.
 			local t = args.time
 			if t - prev > 1 then
 				prev = t
-				-- Stuns at 5 stacks
-				self:StackMessage(args.spellId, "red", args.destName, amount, 4)
-				if amount == 4 then
+				-- Stuns at 10 stacks
+				self:StackMessage(args.spellId, "red", args.destName, amount, 8)
+				if amount >= 8 then
 					self:PlaySound(args.spellId, "warning", nil, args.destName)
 				else
 					self:PlaySound(args.spellId, "alert", nil, args.destName)


### PR DESCRIPTION
- Now stuns at 10 instead of 5
- Can now be dispelled by movement-dispelling effects