### PR TITLE
Legion/Karazhan/Curator: Evocation timer updates

### DIFF
--- a/Legion/Karazhan/Curator.lua
+++ b/Legion/Karazhan/Curator.lua
@@ -34,9 +34,9 @@ function mod:OnEngage()
 	self:SetStage(1)
 	self:Bar(227267, 5) -- Summon Volatile Energy
 	self:CDBar(227279, 12) -- Power Discharge
-	-- Mythic Plus:   900 energy, loses 13/second => 69.2 seconds
-	-- Heroic/Mythic: 575 energy, loses 8/second => 71.9 seconds
-	self:Bar(227254, self:MythicPlus() and 69.4 or 71.5) -- Evocation
+	-- Mythic Plus:   900 energy, loses 18/second => 50.0 seconds
+	-- Heroic/Mythic: 575 energy, loses 10/second => 57.5 seconds
+	self:Bar(227254, self:MythicPlus() and 50 or 57.3) -- Evocation
 end
 
 --------------------------------------------------------------------------------
@@ -94,9 +94,9 @@ do
 			self:StopBar(CL.cast:format(args.spellName))
 			self:Message(args.spellId, "cyan", CL.over:format(args.spellName))
 			self:PlaySound(args.spellId, "info")
-			-- Mythic Plus:   900 energy, loses 13/second => 69.2 seconds
-			-- Heroic/Mythic: 575 energy, loses 8/second => 71.9 seconds
-			self:Bar(args.spellId, self:MythicPlus() and 68.7 or 71)
+			-- Mythic Plus:   900 energy, loses 18/second => 50.0 seconds
+			-- Heroic/Mythic: 575 energy, loses 10/second => 57.5 seconds
+			self:Bar(args.spellId, self:MythicPlus() and 49.25 or 56.5)
 		end
 	end
 end


### PR DESCRIPTION
Due to yet another hotfix, reverts timer changes from #811 and #813.