### PR TITLE
Two new spells for Ruby Lifepools

### DIFF
--- a/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
+++ b/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
@@ -21,11 +21,10 @@ local awakenWhelpsCount = 0
 function mod:GetOptions()
 	return {
 		373046, -- Awaken Whelps
-		{ 372682, "DISPEL" }, -- Primal Chill
+		{372682, "DISPEL"}, -- Primal Chill
 		373680, -- Frost Overload
-		{ 372851, "SAY", "SAY_COUNTDOWN" }, -- Chillstorm
+		{372851, "SAY", "SAY_COUNTDOWN"}, -- Chillstorm
 		396044, -- Hailbombs
-		{ 372808, "TANK_HEALER" }, -- Frigid Shard
 	}
 end
 
@@ -67,8 +66,7 @@ do
 		local amount = args.amount
 		-- start warning at half the required stacks to stun
 		local aboveThreshold = amount >= primalChillMax / 2 and amount < primalChillMax
-		local shouldWarn = self:Dispeller("magic", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) or
-			self:Me(args.destGUID)
+		local shouldWarn = self:Dispeller("magic", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) or self:Me(args.destGUID)
 		if aboveThreshold and shouldWarn then
 			-- this can sometimes apply rapidly or to more than one person, so add a short throttle.
 			local t = args.time

--- a/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
+++ b/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
@@ -25,7 +25,7 @@ function mod:GetOptions()
 		373680, -- Frost Overload
 		{ 372851, "SAY", "SAY_COUNTDOWN" }, -- Chillstorm
 		396044, -- Hailbombs
-		{ 372808, "TANK_HEALER" }, -- FrigidShard
+		{ 372808, "TANK_HEALER" }, -- Frigid Shard
 	}
 end
 

--- a/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
+++ b/Dragonflight/RubyLifePools/MelidrussaChillworn.lua
@@ -21,10 +21,11 @@ local awakenWhelpsCount = 0
 function mod:GetOptions()
 	return {
 		373046, -- Awaken Whelps
-		{372682, "DISPEL"}, -- Primal Chill
+		{ 372682, "DISPEL" }, -- Primal Chill
 		373680, -- Frost Overload
-		{372851, "SAY", "SAY_COUNTDOWN"}, -- Chillstorm
+		{ 372851, "SAY", "SAY_COUNTDOWN" }, -- Chillstorm
 		396044, -- Hailbombs
+		{ 372808, "TANK_HEALER" }, -- FrigidShard
 	}
 end
 
@@ -66,7 +67,8 @@ do
 		local amount = args.amount
 		-- start warning at half the required stacks to stun
 		local aboveThreshold = amount >= primalChillMax / 2 and amount < primalChillMax
-		local shouldWarn = self:Dispeller("magic", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) or self:Me(args.destGUID)
+		local shouldWarn = self:Dispeller("magic", nil, args.spellId) or self:Dispeller("movement", nil, args.spellId) or
+			self:Me(args.destGUID)
 		if aboveThreshold and shouldWarn then
 			-- this can sometimes apply rapidly or to more than one person, so add a short throttle.
 			local t = args.time
@@ -115,4 +117,9 @@ function mod:Hailbombs(args)
 	self:Message(args.spellId, "orange")
 	self:PlaySound(args.spellId, "alarm")
 	self:CDBar(args.spellId, 23)
+end
+
+function mod:FrigidShard(args)
+	self:Message(args.spellId, "purple")
+	self:PlaySound(args.spellId, "alert")
 end

--- a/Dragonflight/RubyLifePools/Trash.lua
+++ b/Dragonflight/RubyLifePools/Trash.lua
@@ -38,6 +38,7 @@ function mod:GetOptions()
 	return {
 		-- Primal Juggernaut
 		372696, -- Excavating Blast
+		{372730, "TANK_HEALER"}, -- Crushing Smash
 		-- Flashfrost Chillweaver
 		372743, -- Ice Shield
 		-- Defier Draghar
@@ -107,6 +108,11 @@ end
 
 function mod:ExcavatingBlast(args)
 	self:Message(args.spellId, "orange", CL.casting:format(args.spellName))
+	self:PlaySound(args.spellId, "alarm")
+end
+
+function mod:CrushingSmash(args)
+	self:Message(args.spellId, "purple")
 	self:PlaySound(args.spellId, "alarm")
 end
 


### PR DESCRIPTION
Would help me to have these 2 abilities in the game.

- "Frigid Shard" for Melidrussa Chillworn.
- "Crushing Smash" for Primal Juggernaut.

Not sure what the difference is between "TANK_HEALER" and "TANK". I hope "TANK_HEALER" is fine.

Edit: 
"TANK" is for frontals only I guess.
