### PR TITLE
Update gossip APIs for WotLK

### DIFF
--- a/TBC/OldHillsbradFoothills/Trash.lua
+++ b/TBC/OldHillsbradFoothills/Trash.lua
@@ -54,11 +54,7 @@ end
 
 function mod:GOSSIP_SHOW()
 	if self:GetOption("custom_on_autotalk") then
-		if self:Classic() then
-			if GetNumGossipAvailableQuests() > 0 or GetNumGossipActiveQuests() > 0 then return end -- let the player take / turn in the quest
-		else
-			if C_GossipInfo.GetNumAvailableQuests() > 0 or C_GossipInfo.GetNumActiveQuests() > 0 then return end -- let the player take / turn in the quest
-		end
+		if C_GossipInfo.GetNumAvailableQuests() > 0 or C_GossipInfo.GetNumActiveQuests() > 0 then return end -- let the player take / turn in the quest
 
 		-- If the player is in a group, do not free Thrall automatically,
 		-- because they may deny others a chance to turn in the quest.

--- a/WotLK/TheCullingOfStratholme/Trash.lua
+++ b/WotLK/TheCullingOfStratholme/Trash.lua
@@ -59,11 +59,7 @@ function mod:GOSSIP_SHOW()
 	if self:GetOption("custom_on_autotalk") then
 		local mobId = self:MobId(self:UnitGUID("npc"))
 		if mobId == 26527 or mobId == 27915 then -- Chromie
-			if self:Classic() then
-				if GetNumGossipAvailableQuests() > 0 or GetNumGossipActiveQuests() > 0 then return end -- let the player take / turn in the quest
-			else
-				if C_GossipInfo.GetNumAvailableQuests() > 0 or C_GossipInfo.GetNumActiveQuests() > 0 then return end -- let the player take / turn in the quest
-			end
+			if C_GossipInfo.GetNumAvailableQuests() > 0 or C_GossipInfo.GetNumActiveQuests() > 0 then return end -- let the player take / turn in the quest
 
 			local gossipTbl = self:GetGossipOptions()
 			if gossipTbl then


### PR DESCRIPTION
In WotLK Classic patch 3.4.1 Blizzard has updated many of their APIs to parity with changes made in 10.0.2 for Dragonflight. BigWigs classic will need updates as well to account for this.

https://wowpedia.fandom.com/wiki/Patch_3.4.1/API_changes

Fixes #871, but there will be errors later on until BigWigs is updated as well.