### PR TITLE
improve power vacuum timers

### DIFF
--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -83,7 +83,7 @@ function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 		powerVacuumCount = powerVacuumCount + 1
 		self:Message(388822, "red")
 		self:PlaySound(388822, "alarm")
-		self:CDBar(388822, powerVacuumCount == 1 and 24 or 29)
+		self:Bar(388822, powerVacuumCount == 1 and 24 or 29)
 	end
 end
 

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -42,7 +42,7 @@ end
 function mod:OnEngage()
 	powerVacuumCount = 0
 	self:CDBar(374352, 14.9) -- Energy Bomb
-	self:CDBar(388822, 22.6) -- Power Vacuum
+	self:Bar(388822, 22.6) -- Power Vacuum
 	self:CDBar(374361, 28.8) -- Astral Breath
 end
 

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -23,7 +23,7 @@ function mod:GetOptions()
 		389011, -- Overwhelming Power
 		388901, -- Arcane Rift
 		374361, -- Astral Breath
-		388820, -- Power Vacuum
+		388822, -- Power Vacuum
 		{374352, "SAY", "SAY_COUNTDOWN"}, -- Energy Bomb
 	}
 end
@@ -42,7 +42,7 @@ end
 function mod:OnEngage()
 	powervacuumCount = 0
 	self:CDBar(374352, 14.9) -- Energy Bomb
-	self:CDBar(388820, 22.6) -- Power Vacuum
+	self:CDBar(388822, 22.6) -- Power Vacuum
 	self:CDBar(374361, 28.8) -- Astral Breath
 end
 
@@ -81,10 +81,10 @@ end
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 388820 then -- Power Vacuum
 		powervacuumCount = powervacuumCount + 1
-		self:StopBar(spellId)
-		self:Message(spellId, "red")
-		self:PlaySound(spellId, "alarm")
-		self:CDBar(spellId, powervacuumCount == 1 and 24 or 29)
+		self:StopBar(388822)
+		self:Message(388822, "red")
+		self:PlaySound(388822, "alarm")
+		self:CDBar(388822, powervacuumCount == 1 and 24 or 29)
 	end
 end
 

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -12,7 +12,7 @@ mod:SetRespawnTime(30)
 -- Locals
 --
 
-local powervacuumCount = 0
+local powerVacuumCount = 0
 
 --------------------------------------------------------------------------------
 -- Initialization
@@ -40,7 +40,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
-	powervacuumCount = 0
+	powerVacuumCount = 0
 	self:CDBar(374352, 14.9) -- Energy Bomb
 	self:CDBar(388822, 22.6) -- Power Vacuum
 	self:CDBar(374361, 28.8) -- Astral Breath
@@ -80,11 +80,11 @@ end
 
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 388820 then -- Power Vacuum
-		powervacuumCount = powervacuumCount + 1
+		powerVacuumCount = powerVacuumCount + 1
 		self:StopBar(388822)
 		self:Message(388822, "red")
 		self:PlaySound(388822, "alarm")
-		self:CDBar(388822, powervacuumCount == 1 and 24 or 29)
+		self:CDBar(388822, powerVacuumCount == 1 and 24 or 29)
 	end
 end
 

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -81,7 +81,6 @@ end
 function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
 	if spellId == 388820 then -- Power Vacuum
 		powerVacuumCount = powerVacuumCount + 1
-		self:StopBar(388822)
 		self:Message(388822, "red")
 		self:PlaySound(388822, "alarm")
 		self:CDBar(388822, powerVacuumCount == 1 and 24 or 29)

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -40,6 +40,7 @@ function mod:OnBossEnable()
 end
 
 function mod:OnEngage()
+	powervacuumCount = 0
 	self:CDBar(374352, 14.9) -- Energy Bomb
 	self:CDBar(388820, 22.6) -- Power Vacuum
 	self:CDBar(374361, 28.8) -- Astral Breath

--- a/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
+++ b/Dragonflight/AlgetharAcademy/EchoOfDoragosa.lua
@@ -9,6 +9,12 @@ mod:SetEncounterID(2565)
 mod:SetRespawnTime(30)
 
 --------------------------------------------------------------------------------
+-- Locals
+--
+
+local powervacuumCount = 0
+
+--------------------------------------------------------------------------------
 -- Initialization
 --
 
@@ -17,25 +23,25 @@ function mod:GetOptions()
 		389011, -- Overwhelming Power
 		388901, -- Arcane Rift
 		374361, -- Astral Breath
-		388822, -- Power Vacuum
+		388820, -- Power Vacuum
 		{374352, "SAY", "SAY_COUNTDOWN"}, -- Energy Bomb
 	}
 end
 
 function mod:OnBossEnable()
+	self:RegisterUnitEvent("UNIT_SPELLCAST_SUCCEEDED", nil, "boss1")
 	self:Log("SPELL_AURA_APPLIED", "OverwhelmingPowerApplied", 389011)
 	self:Log("SPELL_AURA_APPLIED_DOSE", "OverwhelmingPowerApplied", 389011)
 	self:Log("SPELL_AURA_APPLIED", "WildEnergyDamage", 389007)
 	self:Log("SPELL_PERIODIC_DAMAGE", "WildEnergyDamage", 389007)
 	self:Log("SPELL_CAST_START", "AstralBreath", 374361)
-	self:Log("SPELL_CAST_START", "PowerVacuum", 388822)
 	self:Log("SPELL_AURA_APPLIED", "EnergyBombApplied", 374350)
 	self:Log("SPELL_AURA_REMOVED", "EnergyBombRemoved", 374350)
 end
 
 function mod:OnEngage()
 	self:CDBar(374352, 14.9) -- Energy Bomb
-	self:CDBar(388822, 24.2) -- Power Vacuum
+	self:CDBar(388820, 22.6) -- Power Vacuum
 	self:CDBar(374361, 28.8) -- Astral Breath
 end
 
@@ -71,10 +77,14 @@ function mod:AstralBreath(args)
 	self:CDBar(args.spellId, 32.8)
 end
 
-function mod:PowerVacuum(args)
-	self:Message(args.spellId, "red")
-	self:PlaySound(args.spellId, "alarm")
-	self:CDBar(args.spellId, 23.1)
+function mod:UNIT_SPELLCAST_SUCCEEDED(_, _, _, spellId)
+	if spellId == 388820 then -- Power Vacuum
+		powervacuumCount = powervacuumCount + 1
+		self:StopBar(spellId)
+		self:Message(spellId, "red")
+		self:PlaySound(spellId, "alarm")
+		self:CDBar(spellId, powervacuumCount == 1 and 24 or 29)
+	end
 end
 
 function mod:EnergyBombApplied(args)


### PR DESCRIPTION
the timer previously tracked the cast that you have to run out of instead of the "pull in" mechanic.
e.g pull in happens -> cast that you run out of.

 tracking the pull instead allows players to use alter time or similar to avoid being pulled it.
also the timers were off for anything past the first timer