### PR TITLE
Fix roleplay skip in Culling of Strat

### DIFF
--- a/WotLK/TheCullingOfStratholme/Trash.lua
+++ b/WotLK/TheCullingOfStratholme/Trash.lua
@@ -64,7 +64,7 @@ function mod:GOSSIP_SHOW()
 			local gossipTbl = self:GetGossipOptions()
 			if gossipTbl then
 				if gossipTbl[2] then
-					self:SelectGossipOption(2) -- skip the roleplay if possible
+					self:SelectGossipOption(1) -- skip the roleplay if possible
 					self:UnregisterEvent("CHAT_MSG_MONSTER_SAY")
 				elseif gossipTbl[1] then
 					self:SelectGossipOption(1)

--- a/WotLK/TheCullingOfStratholme/Trash.lua
+++ b/WotLK/TheCullingOfStratholme/Trash.lua
@@ -63,8 +63,8 @@ function mod:GOSSIP_SHOW()
 
 			local gossipTbl = self:GetGossipOptions()
 			if gossipTbl then
-				if gossipTbl[2] then
-					self:SelectGossipOption(1) -- skip the roleplay if possible
+				if gossipTbl[2] and self:GetGossipID(93130) then
+					self:SelectGossipID(93130) -- skip the roleplay if possible
 					self:UnregisterEvent("CHAT_MSG_MONSTER_SAY")
 				elseif gossipTbl[1] then
 					self:SelectGossipOption(1)


### PR DESCRIPTION
Currently, the Autoskip option in Culling of Stratholme will select the option of going through the roleplay. This fixes the selection so that the correct/skip option is picked as intended.

![2023-03-09 15_07_14-World of Warcraft](https://user-images.githubusercontent.com/2161018/224180933-17df9ee9-705d-4a94-86f9-1b856a3d0126.png)
