### PR TITLE
BFA/TheUnderrot/Trash: Added Wicked Embrace 

### DIFF
--- a/BfA/Underrot/Options/Sounds.lua
+++ b/BfA/Underrot/Options/Sounds.lua
@@ -41,6 +41,7 @@ BigWigs:AddSounds("Underrot Trash", {
 	[266106] = "warning",
 	[266107] = "alarm",
 	[266209] = {"alarm","alert"},
+	[266265] = {"info"},
 	[272183] = "alert",
 	[272592] = "long",
 	[272609] = "alarm",

--- a/BfA/Underrot/Options/Sounds.lua
+++ b/BfA/Underrot/Options/Sounds.lua
@@ -41,7 +41,7 @@ BigWigs:AddSounds("Underrot Trash", {
 	[266106] = "warning",
 	[266107] = "alarm",
 	[266209] = {"alarm","alert"},
-	[266265] = {"info"},
+	[266265] = {"info", "alert"},
 	[272183] = "alert",
 	[272592] = "long",
 	[272609] = "alarm",

--- a/BfA/Underrot/Trash.lua
+++ b/BfA/Underrot/Trash.lua
@@ -332,6 +332,7 @@ end
 function mod:WickedEmbraceApplied(args)
 	if self:Me(args.destGUID) or self:Healer() or self:Dispeller("magic") then
 		self:TargetMessage(args.spellId, "yellow", args.destName)
+		self:PlaySound(args.spellId, "info", args.destName)
 		self:TargetBar(args.spellId, 12, args.destName)
 	end
 end

--- a/BfA/Underrot/Trash.lua
+++ b/BfA/Underrot/Trash.lua
@@ -332,7 +332,6 @@ end
 function mod:WickedEmbraceApplied(args)
 	if self:Me(args.destGUID) or self:Healer() or self:Dispeller("magic") then
 		self:TargetMessage(args.spellId, "yellow", args.destName)
-		self:PlaySound(args.spellId, "warning", nil, args.destName)
 		self:TargetBar(args.spellId, 12, args.destName)
 	end
 end

--- a/BfA/Underrot/Trash.lua
+++ b/BfA/Underrot/Trash.lua
@@ -331,11 +331,20 @@ end
 
 function mod:WickedEmbraceApplied(args)
 	if self:Me(args.destGUID) or self:Healer() or self:Dispeller("magic") then
-		self:TargetMessage(args.spellId, "yellow", args.destName)
-		self:PlaySound(args.spellId, "info", args.destName)
+		local healthPercent = (UnitHealth(args.destName) / UnitHealthMax(args.destName)) * 100
+		if healthPercent <= 50 then
+			-- If the player's health is below or equal to 50%, play the low health warning
+			self:TargetMessage(args.spellId, "red", args.destName)
+			self:PlaySound(args.spellId, "alert")
+		else
+			-- If the player's health is above 50%, play the regular warning
+			self:TargetMessage(args.spellId, "yellow", args.destName)
+			self:PlaySound(args.spellId, "info", nil, args.destName)
+		end
 		self:TargetBar(args.spellId, 12, args.destName)
 	end
 end
+
 
 -- Grotesque Horror
 

--- a/BfA/Underrot/Trash.lua
+++ b/BfA/Underrot/Trash.lua
@@ -69,6 +69,7 @@ function mod:GetOptions()
 		-- Fallen Deathspeaker
 		272183, -- Raise Dead
 		266209, -- Wicked Frenzy
+		266265, -- Wicked Embrace
 		-- Grotesque Horror
 		413044, -- Dark Echoes
 		-- Bloodsworn Defiler
@@ -130,6 +131,7 @@ function mod:OnBossEnable()
 	-- Fallen Deathspeaker
 	self:Log("SPELL_CAST_START", "RaiseDead", 272183)
 	self:Log("SPELL_CAST_START", "WickedFrenzy", 266209)
+	self:Log("SPELL_AURA_APPLIED", "WickedEmbraceApplied", 266265)
 	self:Log("SPELL_AURA_APPLIED", "WickedFrenzyApplied", 266209)
 
 	-- Grotesque Horror
@@ -323,6 +325,15 @@ do
 				self:PlaySound(args.spellId, "alarm")
 			end
 		end
+	end
+end
+
+
+function mod:WickedEmbraceApplied(args)
+	if self:Me(args.destGUID) or self:Healer() or self:Dispeller("magic") then
+		self:TargetMessage(args.spellId, "yellow", args.destName)
+		self:PlaySound(args.spellId, "warning", nil, args.destName)
+		self:TargetBar(args.spellId, 12, args.destName)
 	end
 end
 


### PR DESCRIPTION
Added Wicked Embrace, the dot from Fallen Deathspeaker's. Magic debuff that must be dispelled, very deadly on higher keys.
The function will give activate an info ping for those who can dispel magic and the victim when the dot goes out. Additionally, if the victim is below 50% when the dot goes onto them it will instead play an alert, since it will most likely one shot them when it ticks (The dot has a delay before first ticking)