### PR TITLE
Update Crushto.lua

### DIFF
--- a/WoD/BloodmaulSlagMines/Crushto.lua
+++ b/WoD/BloodmaulSlagMines/Crushto.lua
@@ -23,6 +23,7 @@ function mod:GetOptions()
 	return {
 		150753, -- Wild Slam
 		150759, -- Ferocious Yell
+		153679, -- Earth Crush
 		{150751, "FLASH", "ICON"}, -- Crushing Leap
 	}
 end
@@ -30,6 +31,7 @@ end
 function mod:OnBossEnable()
 	self:Log("SPELL_CAST_START", "FerociousYell", 150759)
 	self:Log("SPELL_CAST_START", "WildSlam", 150753)
+	self:Log("SPELL_CAST_START", "EarthCrush", 153679)
 	self:Log("SPELL_AURA_APPLIED", "CrushingLeap", 150751)
 	self:Log("SPELL_AURA_REMOVED", "CrushingLeapOver", 150751)
 end
@@ -49,6 +51,10 @@ function mod:FerociousYell(args)
 end
 
 function mod:WildSlam(args)
+	self:MessageOld(args.spellId, "yellow", "long")
+end
+
+function mod:EarthCrush(args)
 	self:MessageOld(args.spellId, "yellow", "long")
 end
 


### PR DESCRIPTION
Added Slave Watcher Crushto ability "Earth Crush", although I fail to enable options to chose soundeffect. I have simply copied the function of "Wild Slam" ability (for which I have the option of chosing soundeffect) but still can't get it to work