### PR TITLE
Fix Smash in Mage Tower

### DIFF
--- a/Legion/ArtifactScenarios/Kruul.lua
+++ b/Legion/ArtifactScenarios/Kruul.lua
@@ -176,8 +176,8 @@ function mod:AuraOfDecay(args)
 end
 
 function mod:Smash(args)
-	self:Message(args.spellId, "red")
-	self:PlaySound(args.spellId, "alarm")
+	self:Message(234631, "red")
+	self:PlaySound(234631, "alarm")
 end
 
 function mod:KruulIncoming(args)


### PR DESCRIPTION
Smash is changed to spell id 236537 and 241717