### PR TITLE
NexusPointXenas/Nysarra: Allow 61s Null Vanguard in stage 2

### DIFF
--- a/Midnight/NexusPointXenas/Nysarra.lua
+++ b/Midnight/NexusPointXenas/Nysarra.lua
@@ -111,7 +111,7 @@ function mod:ENCOUNTER_TIMELINE_EVENT_ADDED(_, eventInfo)
 	elseif duration == 5 or duration == 18 then -- Eclipsing Step
 		self:CancelBarForSpell(1249014)
 		barInfo = self:EclipsingStepTimeline(eventInfo)
-	elseif self:GetStage() == 1 and (duration == 15 or (duration == 61 and count61 % 2 == 1)) then -- Null Vanguard
+	elseif (self:GetStage() == 1 and duration == 15) or (duration == 61 and count61 % 2 == 1) then -- Null Vanguard
 		self:CancelBarForSpell(1252703)
 		barInfo = self:NullVanguardTimeline(eventInfo)
 	elseif duration == 28 or (duration == 61 and count61 % 2 == 0) then -- Lightscar Flare


### PR DESCRIPTION
## What changed

Allow the alternating 61-second Null Vanguard timeline event to be handled during stage 2.

The stage 1 restriction is still applied to the ambiguous 15-second event, which distinguishes Null Vanguard from Devour the Unworthy based on the current stage.

## Why

Corewarden Nysarra can emit a 61-second Null Vanguard event during stage 2. The existing condition applies the stage 1 restriction to both the 15-second and 61-second variants, causing the valid event to fall through to `ErrorForTimelineEvent`.

Observed diagnostic:

```
TL event after 15.6s (stage 2), Null Vanguard (5) (1252703), duration was 61.
```

## Validation

- Confirmed in-game on Mythic+ that the timeline warning no longer occurs.
- Verified the stage/duration cases: stage 1 at 15 seconds remains accepted, stage 2 at 15 seconds remains reserved for Devour the Unworthy, and odd 61-second events are accepted in both stages.
- `git diff --check`
